### PR TITLE
Bump Terraform MCP Server chart version to 0.1.1

### DIFF
--- a/charts/terraform-mcp-server/Chart.yaml
+++ b/charts/terraform-mcp-server/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: terraform-mcp-server
 description: A Helm chart for Terraform MCP Server
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.3.3"

--- a/charts/terraform-mcp-server/README.md
+++ b/charts/terraform-mcp-server/README.md
@@ -1,6 +1,6 @@
 # terraform-mcp-server
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.3](https://img.shields.io/badge/AppVersion-0.3.3-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.3.3](https://img.shields.io/badge/AppVersion-0.3.3-informational?style=flat-square)
 
 A Helm chart for Terraform MCP Server
 

--- a/charts/terraform-mcp-server/templates/ingress.yaml
+++ b/charts/terraform-mcp-server/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "terraform-mcp-server.fullname" . }}
+  labels:
+    {{- include "terraform-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              service:
+                name: {{ include "terraform-mcp-server.fullname" $ }}
+                port:
+                  number: {{ $.Values.service.port }}
+          {{- end }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- Bump the Terraform MCP Server Helm chart version from 0.1.0 to 0.1.1 to reflect the addition of ingress support in the previous PR