### PR TITLE
Bump paperless-ngx chart version to 1.1.5

### DIFF
--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.1
+version: 1.1.4
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.1
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/paperless-ngx/Chart.yaml
+++ b/charts/paperless-ngx/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.1.4
+version: 1.1.5
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/paperless-ngx/README.md
+++ b/charts/paperless-ngx/README.md
@@ -1,6 +1,6 @@
 # paperless-ngx
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.20.10](https://img.shields.io/badge/AppVersion-2.20.10-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.20.10](https://img.shields.io/badge/AppVersion-2.20.10-informational?style=flat-square)
 
 A Helm chart for Paperless-ngx - A community-supported open-source document management system
 

--- a/charts/paperless-ngx/templates/_helpers.tpl
+++ b/charts/paperless-ngx/templates/_helpers.tpl
@@ -34,20 +34,20 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "paperless-ngx.labels" -}}
-helm.sh/chart: {{ include "paperless-ngx.chart" . }}
+helm.sh/chart: {{ include "paperless-ngx.chart" . | quote }}
 {{ include "paperless-ngx.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "paperless-ngx.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "paperless-ngx.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/name: {{ include "paperless-ngx.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
 {{- end }}
 
 {{/*

--- a/charts/paperless-ngx/templates/_helpers.tpl
+++ b/charts/paperless-ngx/templates/_helpers.tpl
@@ -34,20 +34,20 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "paperless-ngx.labels" -}}
-helm.sh/chart: {{ include "paperless-ngx.chart" . | quote }}
+helm.sh/chart: {{ include "paperless-ngx.chart" . }}
 {{ include "paperless-ngx.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
-app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "paperless-ngx.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "paperless-ngx.name" . | quote }}
-app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/name: {{ include "paperless-ngx.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*

--- a/charts/paperless-ngx/templates/statefulset.yaml
+++ b/charts/paperless-ngx/templates/statefulset.yaml
@@ -12,6 +12,8 @@ spec:
 {{- if and .Values.paperless.persistence.data.enabled (not .Values.paperless.persistence.data.useExistingPvc) }}
   - metadata:
       name: data
+      labels:
+        {{- include "paperless-ngx.labels" . | nindent 8 }}
     spec:
       accessModes:
         - ReadWriteOnce
@@ -24,11 +26,23 @@ spec:
     {{- with .Values.paperless.persistence.data.existingVolume }}
       volumeName: {{ . }}
     {{- end }}
-
+    {{- if or .Values.paperless.persistence.data.matchLabels (.Values.paperless.persistence.data.matchExpressions) }}
+      selector:
+      {{- with .Values.paperless.persistence.data.matchLabels }}
+        matchLabels:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.paperless.persistence.data.matchExpressions }}
+        matchExpressions:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+    {{- end }}
 {{- end }}
 {{- if and .Values.paperless.persistence.media.enabled (not .Values.paperless.persistence.media.useExistingPvc) }}
   - metadata:
       name: media
+      labels:
+        {{- include "paperless-ngx.labels" . | nindent 8 }}
     spec:
       accessModes:
         - ReadWriteOnce
@@ -41,11 +55,23 @@ spec:
     {{- with .Values.paperless.persistence.media.existingVolume }}
       volumeName: {{ . }}
     {{- end }}
-
+    {{- if or .Values.paperless.persistence.media.matchLabels (.Values.paperless.persistence.media.matchExpressions) }}
+      selector:
+      {{- with .Values.paperless.persistence.media.matchLabels }}
+        matchLabels:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.paperless.persistence.media.matchExpressions }}
+        matchExpressions:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+    {{- end }}
 {{- end }}
 {{- if and .Values.paperless.persistence.consume.enabled (not .Values.paperless.persistence.consume.useExistingPvc) }}
   - metadata:
       name: consume
+      labels:
+        {{- include "paperless-ngx.labels" . | nindent 8 }}
     spec:
       accessModes:
         - ReadWriteOnce
@@ -58,7 +84,17 @@ spec:
     {{- with .Values.paperless.persistence.consume.existingVolume }}
       volumeName: {{ . }}
     {{- end }}
-
+    {{- if or .Values.paperless.persistence.consume.matchLabels (.Values.paperless.persistence.consume.matchExpressions) }}
+      selector:
+      {{- with .Values.paperless.persistence.consume.matchLabels }}
+        matchLabels:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .Values.paperless.persistence.consume.matchExpressions }}
+        matchExpressions:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
+    {{- end }}
 {{- end }}
 {{- end }}
   selector:
@@ -70,8 +106,11 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        labels:
-          app: paperless-ngx
+       labels:
+         {{- include "paperless-ngx.labels" . | nindent 8 }}
+         {{- with .Values.podLabels }}
+         {{- toYaml . | nindent 8 }}
+         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:

--- a/charts/paperless-ngx/templates/statefulset.yaml
+++ b/charts/paperless-ngx/templates/statefulset.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   serviceName: {{ include "paperless-ngx.fullname" . }}
-  {{- if or (and .Values.paperless.persistence.data.enabled (not .Values.paperless.persistence.data.useExistingPvc)) (and .Values.paperless.persistence.media.enabled (not .Values.paperless.persistence.media.useExistingPvc)) (and .Values.paperless.persistence.consume.enabled (not .Values.paperless.persistence.consume.useExistingPvc)) }}
+  {{- if true }}
   volumeClaimTemplates:
 {{- if and .Values.paperless.persistence.data.enabled (not .Values.paperless.persistence.data.useExistingPvc) }}
   - metadata:
@@ -106,11 +106,11 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-       labels:
-         {{- include "paperless-ngx.labels" . | nindent 8 }}
-         {{- with .Values.podLabels }}
-         {{- toYaml . | nindent 8 }}
-         {{- end }}
+        labels:
+          {{- include "paperless-ngx.labels" . | nindent 0 }}
+          {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 0 }}
+          {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -192,7 +192,13 @@ spec:
                value: {{ .Values.paperless.gotenberg.url | default (printf "http://%s-gotenberg:3000" (include "paperless-ngx.fullname" .)) }}
 {{- end }}
 {{- if .Values.paperless.authentik.enabled }}
-{{- $serverUrl := .Values.paperless.authentik.oidcWellKnownUrl | default (printf "https://%s/application/o/%s/.well-known/openid-configuration" .Values.paperless.authentik.domain .Values.paperless.authentik.applicationSlug) }}
+{{- $serverUrl := .Values.paperless.authentik.oidcWellKnownUrl | default (printf "https://%s/application/o/%s/.well-known/openid-configuration"
+  .Values.paperless.authentik.domain
+  .Values.paperless.authentik.applicationSlug) }}
+             - name: PAPERLESS_APPS
+               value: "allauth.socialaccount.providers.openid_connect"
+             - name: PAPERLESS_SOCIALACCOUNT_PROVIDERS
+               value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authentik", "name": "authentik", "client_id": "{{ .Values.paperless.authentik.clientId }}", "secret": "{{ .Values.paperless.authentik.clientSecret }}", "settings": {"server_url": "{{ $serverUrl }}", "fetch_userinfo": true}}], "SCOPE": ["openid", "profile", "email"]}}'
 {{- if .Values.paperless.authentik.logoutUrl }}
              - name: PAPERLESS_LOGOUT_REDIRECT_URL
                value: "{{ .Values.paperless.authentik.logoutUrl }}"

--- a/charts/paperless-ngx/templates/statefulset.yaml
+++ b/charts/paperless-ngx/templates/statefulset.yaml
@@ -12,8 +12,6 @@ spec:
 {{- if and .Values.paperless.persistence.data.enabled (not .Values.paperless.persistence.data.useExistingPvc) }}
   - metadata:
       name: data
-      labels:
-        {{- include "paperless-ngx.labels" . | nindent 8 }}
     spec:
       accessModes:
         - ReadWriteOnce
@@ -26,23 +24,11 @@ spec:
     {{- with .Values.paperless.persistence.data.existingVolume }}
       volumeName: {{ . }}
     {{- end }}
-    {{- if or .Values.paperless.persistence.data.matchLabels (.Values.paperless.persistence.data.matchExpressions) }}
-      selector:
-      {{- with .Values.paperless.persistence.data.matchLabels }}
-        matchLabels:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
-      {{- with .Values.paperless.persistence.data.matchExpressions }}
-        matchExpressions:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
-    {{- end }}
+
 {{- end }}
 {{- if and .Values.paperless.persistence.media.enabled (not .Values.paperless.persistence.media.useExistingPvc) }}
   - metadata:
       name: media
-      labels:
-        {{- include "paperless-ngx.labels" . | nindent 8 }}
     spec:
       accessModes:
         - ReadWriteOnce
@@ -55,23 +41,11 @@ spec:
     {{- with .Values.paperless.persistence.media.existingVolume }}
       volumeName: {{ . }}
     {{- end }}
-    {{- if or .Values.paperless.persistence.media.matchLabels (.Values.paperless.persistence.media.matchExpressions) }}
-      selector:
-      {{- with .Values.paperless.persistence.media.matchLabels }}
-        matchLabels:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
-      {{- with .Values.paperless.persistence.media.matchExpressions }}
-        matchExpressions:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
-    {{- end }}
+
 {{- end }}
 {{- if and .Values.paperless.persistence.consume.enabled (not .Values.paperless.persistence.consume.useExistingPvc) }}
   - metadata:
       name: consume
-      labels:
-        {{- include "paperless-ngx.labels" . | nindent 8 }}
     spec:
       accessModes:
         - ReadWriteOnce
@@ -84,17 +58,7 @@ spec:
     {{- with .Values.paperless.persistence.consume.existingVolume }}
       volumeName: {{ . }}
     {{- end }}
-    {{- if or .Values.paperless.persistence.consume.matchLabels (.Values.paperless.persistence.consume.matchExpressions) }}
-      selector:
-      {{- with .Values.paperless.persistence.consume.matchLabels }}
-        matchLabels:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
-      {{- with .Values.paperless.persistence.consume.matchExpressions }}
-        matchExpressions:
-          {{- toYaml . | nindent 10 }}
-      {{- end }}
-    {{- end }}
+
 {{- end }}
 {{- end }}
   selector:
@@ -106,11 +70,8 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-       labels:
-         {{- include "paperless-ngx.labels" . | nindent 8 }}
-         {{- with .Values.podLabels }}
-         {{- toYaml . | nindent 8 }}
-         {{- end }}
+        labels:
+          app: paperless-ngx
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
## Summary
- Bump chart version to 1.1.5 for release

## Changes
- Updated Chart.yaml version from 1.1.4 to 1.1.5