### PR TITLE
Fix YAML indentation and parsing errors in paperless-ngx chart

### DIFF
--- a/charts/paperless-ngx/README.md
+++ b/charts/paperless-ngx/README.md
@@ -1,6 +1,6 @@
 # paperless-ngx
 
-![Version: 1.1.4](https://img.shields.io/badge/Version-1.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.20.10](https://img.shields.io/badge/AppVersion-2.20.10-informational?style=flat-square)
+![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 2.20.10](https://img.shields.io/badge/AppVersion-2.20.10-informational?style=flat-square)
 
 A Helm chart for Paperless-ngx - A community-supported open-source document management system
 

--- a/charts/paperless-ngx/templates/statefulset.yaml
+++ b/charts/paperless-ngx/templates/statefulset.yaml
@@ -106,11 +106,11 @@ spec:
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-        labels:
-          {{- include "paperless-ngx.labels" . | nindent 0 }}
-          {{- with .Values.podLabels }}
-          {{- toYaml . | nindent 0 }}
-          {{- end }}
+      labels:
+        {{- include "paperless-ngx.labels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -188,25 +188,25 @@ spec:
               value: {{ .Values.paperless.tika.url | default (printf "http://%s-tika:9998" (include "paperless-ngx.fullname" .)) }}
 {{- end }}
 {{- if .Values.paperless.gotenberg.enabled }}
-             - name: PAPERLESS_GOTENBERG_ENDPOINT
-               value: {{ .Values.paperless.gotenberg.url | default (printf "http://%s-gotenberg:3000" (include "paperless-ngx.fullname" .)) }}
+            - name: PAPERLESS_GOTENBERG_ENDPOINT
+              value: {{ .Values.paperless.gotenberg.url | default (printf "http://%s-gotenberg:3000" (include "paperless-ngx.fullname" .)) }}
 {{- end }}
 {{- if .Values.paperless.authentik.enabled }}
 {{- $serverUrl := .Values.paperless.authentik.oidcWellKnownUrl | default (printf "https://%s/application/o/%s/.well-known/openid-configuration"
   .Values.paperless.authentik.domain
   .Values.paperless.authentik.applicationSlug) }}
-             - name: PAPERLESS_APPS
-               value: "allauth.socialaccount.providers.openid_connect"
-             - name: PAPERLESS_SOCIALACCOUNT_PROVIDERS
-               value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authentik", "name": "authentik", "client_id": "{{ .Values.paperless.authentik.clientId }}", "secret": "{{ .Values.paperless.authentik.clientSecret }}", "settings": {"server_url": "{{ $serverUrl }}", "fetch_userinfo": true}}], "SCOPE": ["openid", "profile", "email"]}}'
+            - name: PAPERLESS_APPS
+              value: "allauth.socialaccount.providers.openid_connect"
+            - name: PAPERLESS_SOCIALACCOUNT_PROVIDERS
+              value: '{"openid_connect": {"OAUTH_PKCE_ENABLED": true, "APPS": [{"provider_id": "authentik", "name": "authentik", "client_id": "{{ .Values.paperless.authentik.clientId }}", "secret": "{{ .Values.paperless.authentik.clientSecret }}", "settings": {"server_url": "{{ $serverUrl }}", "fetch_userinfo": true}}], "SCOPE": ["openid", "profile", "email"]}}'
 {{- if .Values.paperless.authentik.logoutUrl }}
-             - name: PAPERLESS_LOGOUT_REDIRECT_URL
-               value: "{{ .Values.paperless.authentik.logoutUrl }}"
+            - name: PAPERLESS_LOGOUT_REDIRECT_URL
+              value: "{{ .Values.paperless.authentik.logoutUrl }}"
 {{- end }}
-             - name: PAPERLESS_SOCIAL_AUTO_SIGNUP
-               value: {{ .Values.paperless.authentik.autoSignup | quote }}
-             - name: PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS
-               value: {{ .Values.paperless.authentik.allowSignups | quote }}
+            - name: PAPERLESS_SOCIAL_AUTO_SIGNUP
+              value: {{ .Values.paperless.authentik.autoSignup | quote }}
+            - name: PAPERLESS_SOCIALACCOUNT_ALLOW_SIGNUPS
+              value: {{ .Values.paperless.authentik.allowSignups | quote }}
 {{- end }}
 {{- with .Values.paperless.extraEnv }}
             {{- toYaml . | nindent 12 }}
@@ -265,16 +265,6 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
-{{- if .Values.paperless.persistence.consume.enabled }}
-{{- if .Values.paperless.persistence.consume.useExistingPvc }}
-        - name: consume
-          persistentVolumeClaim:
-            claimName: {{ .Values.paperless.persistence.consume.useExistingPvc }}
-{{- end }}
-{{- end }}
-      {{- with .Values.volumes }}
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Summary
- Fixed critical YAML parsing errors in the paperless-ngx StatefulSet template that caused helm lint to fail
- Resolved indentation issues for pod template labels and environment variables
- Removed duplicate volumes block

## Changes Made
1. **Pod Template Labels** (lines 109-113): Corrected indentation of `labels:` key and its nested content
2. **Gotenberg Environment Variables** (lines 191-192): Fixed extra indentation (reduced from 14 to 12 spaces)
3. **Authentik Environment Variables** (lines 198-209): Fixed extra indentation across all Authentik-related env vars
4. **Duplicate Volumes Block** (lines 268-277): Removed redundant volume definitions

## Testing
Ran `helm lint charts/paperless-ngx` which now passes successfully:
```
==> Linting charts/paperless-ngx
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

## Impact
This PR fixes the broken Helm chart and allows it to be deployed without YAML parsing errors.