### PR TITLE
feat(mealie): add ArgoCD PreSync Signal notification hook

### DIFF
--- a/charts/mealie/README.md
+++ b/charts/mealie/README.md
@@ -9,6 +9,12 @@ A Helm chart for Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| argocdHooks.preSyncNotification.enabled | bool | `false` | Enable the ArgoCD PreSync hook that sends a Signal notification before each sync |
+| argocdHooks.preSyncNotification.message | string | `"Mealie is syncing..."` | Message body sent before the sync starts |
+| argocdHooks.preSyncNotification.namespace | string | `"argo"` | Namespace in which the hook Job is created (should match the ArgoCD namespace) |
+| argocdHooks.preSyncNotification.recipients | list | `["+0000000000"]` | List of recipient numbers in international format |
+| argocdHooks.preSyncNotification.sender | string | `"+0000000000"` | Signal sender number in international format (must be registered in signal-cli-rest-api) |
+| argocdHooks.preSyncNotification.signalApiUrl | string | `"http://signal-api:8080"` | Full URL to the signal-cli-rest-api instance (e.g. http://signal-api.signal.svc.cluster.local:8080) |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.tag | string | `"latest"` |  |

--- a/charts/mealie/templates/hooks/pre-sync-notification.yaml
+++ b/charts/mealie/templates/hooks/pre-sync-notification.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.argocdHooks.preSyncNotification.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "mealie.fullname" . }}-pre-sync-notification
+  namespace: {{ .Values.argocdHooks.preSyncNotification.namespace }}
+  labels:
+    {{- include "mealie.labels" . | nindent 4 }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/hook-delete-policy: HookSucceeded
+spec:
+  ttlSecondsAfterFinished: 120
+  template:
+    metadata:
+      name: {{ include "mealie.fullname" . }}-pre-sync-notification
+      labels:
+        {{- include "mealie.selectorLabels" . | nindent 8 }}
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: signal-notification
+          image: curlimages/curl:latest
+          command:
+            - sh
+            - -c
+            - |
+              curl -X POST \
+                -H "Content-Type: application/json" \
+                -d '{"message": "{{ .Values.argocdHooks.preSyncNotification.message }}", "number": "{{ .Values.argocdHooks.preSyncNotification.sender }}", "recipients": {{ .Values.argocdHooks.preSyncNotification.recipients | toJson }}}' \
+                {{ .Values.argocdHooks.preSyncNotification.signalApiUrl }}/v2/send
+{{- end }}

--- a/charts/mealie/values.yaml
+++ b/charts/mealie/values.yaml
@@ -90,6 +90,22 @@ mealie:
       matchExpressions: {}
       size: "1Gi"
 
+argocdHooks:
+  preSyncNotification:
+    # -- Enable the ArgoCD PreSync hook that sends a Signal notification before each sync
+    enabled: false
+    # -- Namespace in which the hook Job is created (should match the ArgoCD namespace)
+    namespace: "argo"
+    # -- Full URL to the signal-cli-rest-api instance (e.g. http://signal-api.signal.svc.cluster.local:8080)
+    signalApiUrl: "http://signal-api:8080"
+    # -- Signal sender number in international format (must be registered in signal-cli-rest-api)
+    sender: "+0000000000"
+    # -- List of recipient numbers in international format
+    recipients:
+      - "+0000000000"
+    # -- Message body sent before the sync starts
+    message: "Mealie is syncing..."
+
 ingress:
   enabled: false
   className: ""


### PR DESCRIPTION
## Summary

- Adds `charts/mealie/templates/hooks/pre-sync-notification.yaml` — an ArgoCD `PreSync` hook that runs a `batch/v1 Job` in a configurable namespace (default: `argo`) before each sync
- The Job uses `curlimages/curl` to POST a message to a [signal-cli-rest-api](https://github.com/bbernhard/signal-cli-rest-api) instance (`POST /v2/send`)
- Hook is **disabled by default** (`argocdHooks.preSyncNotification.enabled: false`) and fully opt-in
- Completed Jobs are automatically cleaned up (`HookSucceeded` delete policy + 120 s TTL)

## New values

| Value | Default | Description |
|---|---|---|
| `argocdHooks.preSyncNotification.enabled` | `false` | Toggle the hook on/off |
| `argocdHooks.preSyncNotification.namespace` | `"argo"` | Namespace where the hook Job is created |
| `argocdHooks.preSyncNotification.signalApiUrl` | `"http://signal-api:8080"` | URL of the signal-cli-rest-api instance |
| `argocdHooks.preSyncNotification.sender` | `"+0000000000"` | Registered Signal sender number |
| `argocdHooks.preSyncNotification.recipients` | `["+0000000000"]` | List of recipient numbers |
| `argocdHooks.preSyncNotification.message` | `"Mealie is syncing..."` | Notification text |

## Test plan

- [x] `helm lint charts/mealie` — passes (info only, no errors)
- [x] Hook disabled (default) — no `Job` resource rendered in full template output
- [x] Hook enabled with default namespace — Job rendered in `namespace: argo`
- [x] Hook enabled with `namespace: argocd` — Job rendered in `namespace: argocd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)