### PR TITLE
chore(mealie): bump chart version from 0.2.2 to 0.2.3

### DIFF
--- a/charts/mealie/Chart.yaml
+++ b/charts/mealie/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/mealie/README.md
+++ b/charts/mealie/README.md
@@ -1,6 +1,6 @@
 # mealie
 
-![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
+![Version: 0.2.3](https://img.shields.io/badge/Version-0.2.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.16.0](https://img.shields.io/badge/AppVersion-1.16.0-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 


### PR DESCRIPTION
## Summary

- Bumps `charts/mealie/Chart.yaml` version from `0.2.2` to `0.2.3`
- Follows the merged feature in #65 (ArgoCD PreSync Signal notification hook)

## Test plan

- [x] `helm lint charts/mealie` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)