### PR TITLE
Add influxdb3-core Helm chart

### DIFF
--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: influxdb3-core
+description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
+type: application
+version: 0.1.0
+appVersion: "3.9.3"
+keywords:
+  - influxdb
+  - time-series
+  - database
+  - metrics
+  - iot
+  - open-source
+home: https://www.influxdata.com/products/influxdb/
+sources:
+  - https://github.com/influxdata/influxdb
+  - https://docs.influxdata.com/influxdb3/core/
+maintainers:
+  - name: NigelVanHattum
+icon: https://www.influxdata.com/wp-content/uploads/influxdata-logo.svg

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -1,0 +1,189 @@
+# influxdb3-core
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+
+A Helm chart for deploying InfluxDB 3 Core on Kubernetes
+
+[InfluxDB 3 Core](https://docs.influxdata.com/influxdb3/core/) is the open source release of InfluxDB 3 — a single-node time series database that persists data as Parquet files in an object store (local filesystem, S3, Azure Blob Storage, or Google Cloud Storage).
+
+This chart deploys InfluxDB 3 Core as a single-replica StatefulSet. For the distributed, multi-component version see the [influxdb3-enterprise](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb3-enterprise) chart.
+
+**Homepage:** <https://www.influxdata.com/products/influxdb/>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| NigelVanHattum |  |  |
+
+## Source Code
+
+* <https://github.com/influxdata/influxdb>
+* <https://docs.influxdata.com/influxdb3/core/>
+
+## Installing
+
+```sh
+helm install influxdb3-core ./charts/influxdb3-core
+```
+
+By default data is stored on a PersistentVolumeClaim using the cluster's default StorageClass.
+
+### Using S3 (or S3-compatible) object storage
+
+```yaml
+objectStorage:
+  type: s3
+  bucket: my-influxdb-bucket
+  s3:
+    region: us-east-1
+    endpoint: ""                # set for MinIO etc., empty for AWS
+    accessKeyId: my-key
+    secretAccessKey: my-secret
+    # or reference an existing secret with keys access-key-id / secret-access-key:
+    # existingSecret: my-s3-secret
+```
+
+### Authentication
+
+Authentication is enabled by default (the `/health` endpoint is exempted so Kubernetes probes work). Create an admin token after install:
+
+```sh
+kubectl exec -it <release-name>-influxdb3-core-0 -- influxdb3 create token --admin
+```
+
+Alternatively, provide an offline-generated admin token via `security.auth.adminToken.existingSecret` (secret key `admin-token.json`).
+
+### Processing engine
+
+The embedded Python processing engine can be enabled with `processingEngine.enabled: true`. Plugins are stored on a dedicated PersistentVolumeClaim and can be pre-installed via `processingEngine.initPlugins`.
+
+Note: enabling the processing engine after the initial install adds a volumeClaimTemplate to the StatefulSet, which requires recreating it first:
+
+```sh
+kubectl delete statefulset <release-name>-influxdb3-core --cascade=orphan
+```
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| caching | string | `nil` |  |
+| extraEnv | list | `[]` |  |
+| extraVolumeMounts | list | `[]` |  |
+| extraVolumes | list | `[]` |  |
+| fullnameOverride | string | `""` |  |
+| http | string | `nil` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.registry | string | `"docker.io"` |  |
+| image.repository | string | `"influxdb"` |  |
+| image.tag | string | `""` | Optional explicit tag override. If empty, defaults to "<appVersion>-core". |
+| imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.host | string | `"influxdb.example.com"` |  |
+| ingress.tls | list | `[]` |  |
+| nameOverride | string | `""` |  |
+| networkPolicy.egress.dns.namespace | string | `"kube-system"` |  |
+| networkPolicy.egress.dns.namespaceLabel | string | `"kubernetes.io/metadata.name"` |  |
+| networkPolicy.egress.dns.podLabelKey | string | `"k8s-app"` |  |
+| networkPolicy.egress.dns.podLabelValue | string | `"kube-dns"` |  |
+| networkPolicy.egress.objectStorageCidrs | list | `[]` |  |
+| networkPolicy.egress.pluginEndpointCidrs | list | `[]` |  |
+| networkPolicy.egress.toDns | bool | `true` |  |
+| networkPolicy.egress.toObjectStorage | bool | `true` |  |
+| networkPolicy.egress.toPluginEndpoints | bool | `true` |  |
+| networkPolicy.enabled | bool | `false` |  |
+| networkPolicy.ingress.fromIngressController | bool | `true` |  |
+| networkPolicy.ingress.fromPrometheus | bool | `false` |  |
+| networkPolicy.ingress.ingressController.namespace | string | `"ingress-nginx"` |  |
+| networkPolicy.ingress.ingressController.namespaceLabel | string | `"kubernetes.io/metadata.name"` |  |
+| networkPolicy.ingress.ingressController.podLabelKey | string | `"app.kubernetes.io/name"` |  |
+| networkPolicy.ingress.ingressController.podLabelValue | string | `"ingress-nginx"` |  |
+| networkPolicy.ingress.prometheus.namespace | string | `"monitoring"` |  |
+| networkPolicy.ingress.prometheus.namespaceLabel | string | `"kubernetes.io/metadata.name"` |  |
+| networkPolicy.ingress.prometheus.podLabelKey | string | `"app.kubernetes.io/name"` |  |
+| networkPolicy.ingress.prometheus.podLabelValue | string | `"prometheus"` |  |
+| networkPolicy.policyTypes[0] | string | `"Ingress"` |  |
+| networkPolicy.policyTypes[1] | string | `"Egress"` |  |
+| node.id | string | `""` | Node identifier, must be unique among hosts sharing the same object store. If empty, the pod hostname is used (stable for a StatefulSet). |
+| nodeSelector | object | `{}` |  |
+| objectStorage.azure.accessKey | string | `""` |  |
+| objectStorage.azure.allowHttp | bool | `false` |  |
+| objectStorage.azure.endpoint | string | `""` |  |
+| objectStorage.azure.existingSecret | string | `""` |  |
+| objectStorage.azure.storageAccount | string | `""` |  |
+| objectStorage.bucket | string | `"influxdb3-core-data"` | Bucket/container name for storing data (s3, azure, google) |
+| objectStorage.file.dataDir | string | `"/var/lib/influxdb3"` |  |
+| objectStorage.file.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| objectStorage.file.persistence.enabled | bool | `true` | Create a PVC for the data directory. When disabled, an emptyDir is used and all data is lost when the pod restarts. |
+| objectStorage.file.persistence.size | string | `"50Gi"` |  |
+| objectStorage.file.persistence.storageClass | string | `""` |  |
+| objectStorage.google.existingSecret | string | `""` |  |
+| objectStorage.google.serviceAccountJson | string | `""` |  |
+| objectStorage.s3.accessKeyId | string | `""` |  |
+| objectStorage.s3.credentialsFile | string | `""` |  |
+| objectStorage.s3.endpoint | string | `""` |  |
+| objectStorage.s3.existingSecret | string | `""` |  |
+| objectStorage.s3.region | string | `"us-east-1"` |  |
+| objectStorage.s3.secretAccessKey | string | `""` |  |
+| objectStorage.s3.sessionToken | string | `""` |  |
+| objectStorage.type | string | `"file"` | Object store type: file, s3, azure, google, memory, memory-throttled |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext.fsGroup | int | `1500` |  |
+| podSecurityContext.runAsGroup | int | `1500` |  |
+| podSecurityContext.runAsNonRoot | bool | `true` |  |
+| podSecurityContext.runAsUser | int | `1500` |  |
+| priorityClassName | string | `""` |  |
+| probes.enabled | bool | `true` |  |
+| probes.liveness.failureThreshold | int | `3` |  |
+| probes.liveness.initialDelaySeconds | int | `0` |  |
+| probes.liveness.periodSeconds | int | `10` |  |
+| probes.liveness.timeoutSeconds | int | `5` |  |
+| probes.readiness.failureThreshold | int | `3` |  |
+| probes.readiness.initialDelaySeconds | int | `0` |  |
+| probes.readiness.periodSeconds | int | `5` |  |
+| probes.readiness.timeoutSeconds | int | `3` |  |
+| probes.startup.failureThreshold | int | `12` |  |
+| probes.startup.initialDelaySeconds | int | `10` |  |
+| probes.startup.periodSeconds | int | `5` |  |
+| probes.startup.timeoutSeconds | int | `5` |  |
+| processingEngine.enabled | bool | `false` |  |
+| processingEngine.initPlugins | list | `[]` |  |
+| processingEngine.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| processingEngine.persistence.enabled | bool | `true` |  |
+| processingEngine.persistence.size | string | `"5Gi"` |  |
+| processingEngine.persistence.storageClass | string | `""` |  |
+| processingEngine.pluginDir | string | `"/plugins"` | Local directory that contains Python plugins and their test files (--plugin-dir) |
+| resources | object | `{}` |  |
+| security.auth.adminToken.existingSecret | string | `""` |  |
+| security.auth.adminToken.file | string | `""` |  |
+| security.auth.disableAuthz[0] | string | `"health"` |  |
+| security.auth.disabled | bool | `false` |  |
+| security.tls.cert | string | `""` |  |
+| security.tls.certPath | string | `"/etc/influxdb/tls/tls.crt"` |  |
+| security.tls.enabled | bool | `false` |  |
+| security.tls.existingSecret | string | `""` |  |
+| security.tls.key | string | `""` |  |
+| security.tls.keyPath | string | `"/etc/influxdb/tls/tls.key"` |  |
+| security.tls.minVersion | string | `"tls-1.2"` |  |
+| securityContext | object | `{}` |  |
+| service.annotations | object | `{}` |  |
+| service.port | int | `8181` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| serviceMonitor.additionalLabels | object | `{}` |  |
+| serviceMonitor.enabled | bool | `false` |  |
+| serviceMonitor.interval | string | `"30s"` |  |
+| serviceMonitor.namespace | string | `""` |  |
+| serviceMonitor.scrapeTimeout | string | `"10s"` |  |
+| tolerations | list | `[]` |  |
+| updateStrategy.type | string | `"RollingUpdate"` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/influxdb3-core/README.md.gotmpl
+++ b/charts/influxdb3-core/README.md.gotmpl
@@ -1,0 +1,64 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+[InfluxDB 3 Core](https://docs.influxdata.com/influxdb3/core/) is the open source release of InfluxDB 3 — a single-node time series database that persists data as Parquet files in an object store (local filesystem, S3, Azure Blob Storage, or Google Cloud Storage).
+
+This chart deploys InfluxDB 3 Core as a single-replica StatefulSet. For the distributed, multi-component version see the [influxdb3-enterprise](https://github.com/influxdata/helm-charts/tree/master/charts/influxdb3-enterprise) chart.
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+## Installing
+
+```sh
+helm install influxdb3-core ./charts/influxdb3-core
+```
+
+By default data is stored on a PersistentVolumeClaim using the cluster's default StorageClass.
+
+### Using S3 (or S3-compatible) object storage
+
+```yaml
+objectStorage:
+  type: s3
+  bucket: my-influxdb-bucket
+  s3:
+    region: us-east-1
+    endpoint: ""                # set for MinIO etc., empty for AWS
+    accessKeyId: my-key
+    secretAccessKey: my-secret
+    # or reference an existing secret with keys access-key-id / secret-access-key:
+    # existingSecret: my-s3-secret
+```
+
+### Authentication
+
+Authentication is enabled by default (the `/health` endpoint is exempted so Kubernetes probes work). Create an admin token after install:
+
+```sh
+kubectl exec -it <release-name>-influxdb3-core-0 -- influxdb3 create token --admin
+```
+
+Alternatively, provide an offline-generated admin token via `security.auth.adminToken.existingSecret` (secret key `admin-token.json`).
+
+### Processing engine
+
+The embedded Python processing engine can be enabled with `processingEngine.enabled: true`. Plugins are stored on a dedicated PersistentVolumeClaim and can be pre-installed via `processingEngine.initPlugins`.
+
+Note: enabling the processing engine after the initial install adds a volumeClaimTemplate to the StatefulSet, which requires recreating it first:
+
+```sh
+kubectl delete statefulset <release-name>-influxdb3-core --cascade=orphan
+```
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/influxdb3-core/ci/default-values.yaml
+++ b/charts/influxdb3-core/ci/default-values.yaml
@@ -1,0 +1,6 @@
+# CI values: small PVC so the chart installs on minimal test clusters
+objectStorage:
+  type: file
+  file:
+    persistence:
+      size: 1Gi

--- a/charts/influxdb3-core/templates/NOTES.txt
+++ b/charts/influxdb3-core/templates/NOTES.txt
@@ -1,0 +1,65 @@
+Thank you for installing {{ .Chart.Name }}!
+
+InfluxDB 3 Core has been deployed to namespace {{ .Release.Namespace }} as a single-node StatefulSet.
+
+{{- if eq .Values.objectStorage.type "file" }}
+{{- if .Values.objectStorage.file.persistence.enabled }}
+
+Storage: local filesystem ({{ .Values.objectStorage.file.dataDir }}) on a {{ .Values.objectStorage.file.persistence.size }} PersistentVolumeClaim.
+{{- else }}
+
+⚠️  WARNING: objectStorage.file.persistence.enabled is false!
+    Data is stored on an emptyDir and will be LOST when the pod restarts.
+{{- end }}
+{{- else if or (eq .Values.objectStorage.type "memory") (eq .Values.objectStorage.type "memory-throttled") }}
+
+⚠️  WARNING: objectStorage.type is "{{ .Values.objectStorage.type }}"!
+    Data is stored in memory and will be LOST when the pod restarts.
+{{- else }}
+
+Storage: {{ .Values.objectStorage.type }} object store, bucket "{{ .Values.objectStorage.bucket }}".
+{{- end }}
+
+{{- $security := .Values.security | default dict }}
+{{- $auth := get $security "auth" | default dict }}
+{{- $adminToken := get $auth "adminToken" | default dict }}
+{{- if get $adminToken "existingSecret" }}
+
+Preconfigured admin token:
+  Enabled via secret: {{ get $adminToken "existingSecret" }}
+  Token file path: /etc/influxdb/admin-token/admin-token.json
+{{- end }}
+
+Access endpoint:
+{{- if .Values.ingress.enabled }}
+  http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}
+{{- else }}
+  kubectl port-forward svc/{{ include "influxdb3-core.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+{{- end }}
+
+Getting started:
+
+  1. Create an admin token:
+
+     kubectl exec -it {{ include "influxdb3-core.fullname" . }}-0 -n {{ .Release.Namespace }} -- \
+        influxdb3 create token --admin
+
+  2. Create a database:
+
+     export INFLUXDB3_AUTH_TOKEN=<your-admin-token>
+{{- if .Values.ingress.enabled }}
+     export INFLUXDB3_HOST_URL=http{{ if .Values.ingress.tls }}s{{ end }}://{{ .Values.ingress.host }}
+{{- else }}
+     export INFLUXDB3_HOST_URL=http://localhost:{{ .Values.service.port }}
+{{- end }}
+     influxdb3 create database mydb
+
+  3. Write data:
+
+     influxdb3 write mydb "measurement field=value"
+
+  4. Query data:
+
+     influxdb3 query mydb "SELECT * FROM measurement"
+
+Documentation: https://docs.influxdata.com/influxdb3/core/

--- a/charts/influxdb3-core/templates/_helpers.tpl
+++ b/charts/influxdb3-core/templates/_helpers.tpl
@@ -1,0 +1,403 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "influxdb3-core.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "influxdb3-core.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "influxdb3-core.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "influxdb3-core.labels" -}}
+helm.sh/chart: {{ include "influxdb3-core.chart" . }}
+{{ include "influxdb3-core.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "influxdb3-core.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "influxdb3-core.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Service account name
+*/}}
+{{- define "influxdb3-core.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "influxdb3-core.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Object storage secret name
+*/}}
+{{- define "influxdb3-core.objectStorageSecretName" -}}
+{{- $type := .Values.objectStorage.type | default "file" -}}
+{{- $defaultSecret := printf "%s-object-storage" (include "influxdb3-core.fullname" .) -}}
+{{- if eq $type "s3" -}}
+{{- $s3 := .Values.objectStorage.s3 | default dict -}}
+{{- get $s3 "existingSecret" | default $defaultSecret -}}
+{{- else if eq $type "azure" -}}
+{{- $azure := .Values.objectStorage.azure | default dict -}}
+{{- get $azure "existingSecret" | default $defaultSecret -}}
+{{- else if eq $type "google" -}}
+{{- $google := .Values.objectStorage.google | default dict -}}
+{{- get $google "existingSecret" | default $defaultSecret -}}
+{{- else -}}
+{{- $defaultSecret -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate object storage type
+*/}}
+{{- define "influxdb3-core.validateObjectStorageType" -}}
+{{- $type := default "file" .Values.objectStorage.type -}}
+{{- $valid := list "s3" "azure" "google" "file" "memory" "memory-throttled" -}}
+{{- if not (has $type $valid) -}}
+{{- fail (printf "Invalid objectStorage.type: %s. Must be one of: %s" $type (join ", " $valid)) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate Azure object storage auth config
+*/}}
+{{- define "influxdb3-core.validateAzureObjectStorageAuth" -}}
+{{- if eq .Values.objectStorage.type "azure" -}}
+{{- $azure := .Values.objectStorage.azure | default dict -}}
+{{- $existingSecret := get $azure "existingSecret" | default "" -}}
+{{- $storageAccount := get $azure "storageAccount" | default "" -}}
+{{- $accessKey := get $azure "accessKey" | default "" -}}
+{{- if not $existingSecret -}}
+{{- if not (and $storageAccount $accessKey) -}}
+{{- fail "When objectStorage.type=azure and objectStorage.azure.existingSecret is not set, both objectStorage.azure.storageAccount and objectStorage.azure.accessKey must be set." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate S3 object storage auth config
+*/}}
+{{- define "influxdb3-core.validateS3ObjectStorageAuth" -}}
+{{- if eq .Values.objectStorage.type "s3" -}}
+{{- $s3 := .Values.objectStorage.s3 | default dict -}}
+{{- $existingSecret := get $s3 "existingSecret" | default "" -}}
+{{- $accessKeyID := get $s3 "accessKeyId" | default "" -}}
+{{- $secretAccessKey := get $s3 "secretAccessKey" | default "" -}}
+{{- $sessionToken := get $s3 "sessionToken" | default "" -}}
+{{- if and (not $existingSecret) (or (and $accessKeyID (not $secretAccessKey)) (and (not $accessKeyID) $secretAccessKey)) -}}
+{{- fail "When objectStorage.type=s3, objectStorage.s3.accessKeyId and objectStorage.s3.secretAccessKey must be set together." -}}
+{{- end -}}
+{{- if and (not $existingSecret) $sessionToken (not (and $accessKeyID $secretAccessKey)) -}}
+{{- fail "When objectStorage.type=s3 and objectStorage.s3.sessionToken is set, both objectStorage.s3.accessKeyId and objectStorage.s3.secretAccessKey must also be set." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate Google object storage auth config
+*/}}
+{{- define "influxdb3-core.validateGoogleObjectStorageAuth" -}}
+{{- if eq .Values.objectStorage.type "google" -}}
+{{- $google := .Values.objectStorage.google | default dict -}}
+{{- $existingSecret := get $google "existingSecret" | default "" -}}
+{{- $serviceAccountJSON := get $google "serviceAccountJson" | default "" -}}
+{{- if not (or $existingSecret $serviceAccountJSON) -}}
+{{- fail "When objectStorage.type=google, set either objectStorage.google.existingSecret or objectStorage.google.serviceAccountJson." -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate object store TLS CA config
+*/}}
+{{- define "influxdb3-core.validateObjectStoreTlsCa" -}}
+{{- $tlsCa := .Values.objectStorage.tlsCa | default dict -}}
+{{- $certPath := get $tlsCa "certPath" | default "" -}}
+{{- $existingSecret := get $tlsCa "existingSecret" | default "" -}}
+{{- if and $certPath $existingSecret -}}
+{{- fail "Set only one of objectStorage.tlsCa.certPath or objectStorage.tlsCa.existingSecret." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Validate admin token bootstrap config
+*/}}
+{{- define "influxdb3-core.validateAdminTokenConfig" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- $existingSecret := get $adminToken "existingSecret" | default "" -}}
+{{- $adminTokenFile := get $adminToken "file" | default "" -}}
+{{- if and $existingSecret $adminTokenFile -}}
+{{- fail "Set only one of security.auth.adminToken.existingSecret or security.auth.adminToken.file." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+TLS secret name
+*/}}
+{{- define "influxdb3-core.tlsSecretName" -}}
+{{- if .Values.security.tls.existingSecret }}
+{{- .Values.security.tls.existingSecret }}
+{{- else }}
+{{- include "influxdb3-core.fullname" . }}-tls
+{{- end }}
+{{- end }}
+
+{{- define "influxdb3-core.objectStoreSecretEnv" -}}
+{{- $objectStoreSecretName := include "influxdb3-core.objectStorageSecretName" . }}
+{{- if eq .Values.objectStorage.type "s3" }}
+  {{- $s3 := .Values.objectStorage.s3 | default dict }}
+  {{- $s3ExistingSecret := get $s3 "existingSecret" | default "" }}
+  {{- $s3AccessKeyID := get $s3 "accessKeyId" | default "" }}
+  {{- $s3SecretAccessKey := get $s3 "secretAccessKey" | default "" }}
+  {{- if or $s3ExistingSecret (and $s3AccessKeyID $s3SecretAccessKey) }}
+- name: AWS_ACCESS_KEY_ID
+  valueFrom:
+    secretKeyRef:
+      name: {{ $objectStoreSecretName }}
+      key: access-key-id
+- name: AWS_SECRET_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $objectStoreSecretName }}
+      key: secret-access-key
+- name: AWS_SESSION_TOKEN
+  valueFrom:
+    secretKeyRef:
+      name: {{ $objectStoreSecretName }}
+      key: session-token
+      optional: true
+  {{- end }}
+{{- else if eq .Values.objectStorage.type "azure" }}
+  {{- $azure := .Values.objectStorage.azure | default dict }}
+  {{- $azureExistingSecret := get $azure "existingSecret" | default "" }}
+  {{- $azureStorageAccount := get $azure "storageAccount" | default "" }}
+  {{- $azureAccessKey := get $azure "accessKey" | default "" }}
+  {{- if $azureExistingSecret }}
+- name: AZURE_STORAGE_ACCOUNT
+  valueFrom:
+    secretKeyRef:
+      name: {{ $objectStoreSecretName }}
+      key: storage-account
+- name: AZURE_STORAGE_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $objectStoreSecretName }}
+      key: access-key
+  {{- else if $azureStorageAccount }}
+- name: AZURE_STORAGE_ACCOUNT
+  value: {{ $azureStorageAccount | quote }}
+  {{- if $azureAccessKey }}
+- name: AZURE_STORAGE_ACCESS_KEY
+  valueFrom:
+    secretKeyRef:
+      name: {{ $objectStoreSecretName }}
+      key: access-key
+  {{- end }}
+  {{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Preconfigured admin token environment
+*/}}
+{{- define "influxdb3-core.adminTokenEnv" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- $adminTokenFile := get $adminToken "file" | default "" -}}
+{{- if get $adminToken "existingSecret" }}
+- name: INFLUXDB3_ADMIN_TOKEN_FILE
+  value: "/etc/influxdb/admin-token/admin-token.json"
+{{- else if $adminTokenFile }}
+- name: INFLUXDB3_ADMIN_TOKEN_FILE
+  value: {{ $adminTokenFile | quote }}
+{{- end }}
+{{- end }}
+
+{{/*
+Probe configuration
+*/}}
+{{- define "influxdb3-core.probes" -}}
+{{- if .Values.probes.enabled }}
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+    {{- if .Values.security.tls.enabled }}
+    scheme: HTTPS
+    {{- end }}
+  initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+  periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+  timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+  failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+    {{- if .Values.security.tls.enabled }}
+    scheme: HTTPS
+    {{- end }}
+  initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+  periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+  timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+  failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+startupProbe:
+  httpGet:
+    path: /health
+    port: http
+    {{- if .Values.security.tls.enabled }}
+    scheme: HTTPS
+    {{- end }}
+  initialDelaySeconds: {{ .Values.probes.startup.initialDelaySeconds }}
+  periodSeconds: {{ .Values.probes.startup.periodSeconds }}
+  timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
+  failureThreshold: {{ .Values.probes.startup.failureThreshold }}
+{{- end }}
+{{- end }}
+
+{{/*
+Image reference
+*/}}
+{{- define "influxdb3-core.image" -}}
+{{- $registry := .Values.image.registry }}
+{{- $repository := .Values.image.repository }}
+{{- $tag := .Values.image.tag | default (printf "%s-core" .Chart.AppVersion) }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- end }}
+
+{{/*
+Shared volume mounts (object storage credentials/TLS and user extras)
+*/}}
+{{- define "influxdb3-core.sharedVolumeMounts" -}}
+{{- if eq .Values.objectStorage.type "google" }}
+- name: google-service-account
+  mountPath: /var/secrets/google
+  readOnly: true
+{{- end }}
+{{- $s3 := .Values.objectStorage.s3 | default dict }}
+{{- if and (eq .Values.objectStorage.type "s3") (get $s3 "credentialsFile") }}
+- name: aws-credentials
+  mountPath: /etc/influxdb/aws
+  readOnly: true
+{{- end }}
+{{- if .Values.security.tls.enabled }}
+- name: tls
+  mountPath: /etc/influxdb/tls
+  readOnly: true
+{{- end }}
+{{- $tlsCa := .Values.objectStorage.tlsCa | default dict }}
+{{- if get $tlsCa "existingSecret" }}
+- name: object-store-ca
+  mountPath: /etc/influxdb/object-store-ca
+  readOnly: true
+{{- end }}
+{{- with .Values.extraVolumeMounts }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Admin token volume mounts
+*/}}
+{{- define "influxdb3-core.adminTokenVolumeMounts" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- if get $adminToken "existingSecret" }}
+- name: admin-token
+  mountPath: /etc/influxdb/admin-token
+  readOnly: true
+{{- end }}
+{{- end }}
+
+{{/*
+Shared volumes (object storage credentials/TLS and user extras)
+*/}}
+{{- define "influxdb3-core.sharedVolumes" -}}
+{{- if eq .Values.objectStorage.type "google" }}
+- name: google-service-account
+  secret:
+    secretName: {{ include "influxdb3-core.objectStorageSecretName" . }}
+    items:
+      - key: service-account.json
+        path: service-account.json
+{{- end }}
+{{- $s3 := .Values.objectStorage.s3 | default dict }}
+{{- if and (eq .Values.objectStorage.type "s3") (get $s3 "credentialsFile") }}
+- name: aws-credentials
+  secret:
+    secretName: {{ include "influxdb3-core.fullname" . }}-aws-credentials
+    items:
+      - key: credentials
+        path: credentials
+{{- end }}
+{{- if .Values.security.tls.enabled }}
+- name: tls
+  secret:
+    secretName: {{ include "influxdb3-core.tlsSecretName" . }}
+{{- end }}
+{{- $tlsCa := .Values.objectStorage.tlsCa | default dict }}
+{{- if get $tlsCa "existingSecret" }}
+- name: object-store-ca
+  secret:
+    secretName: {{ get $tlsCa "existingSecret" }}
+    items:
+      - key: ca.crt
+        path: ca.crt
+{{- end }}
+{{- with .Values.extraVolumes }}
+{{ toYaml . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Admin token volumes
+*/}}
+{{- define "influxdb3-core.adminTokenVolumes" -}}
+{{- $security := .Values.security | default dict -}}
+{{- $auth := get $security "auth" | default dict -}}
+{{- $adminToken := get $auth "adminToken" | default dict -}}
+{{- if get $adminToken "existingSecret" }}
+- name: admin-token
+  secret:
+    secretName: {{ get $adminToken "existingSecret" }}
+    items:
+      - key: admin-token.json
+        path: admin-token.json
+{{- end }}
+{{- end }}

--- a/charts/influxdb3-core/templates/configmap.yaml
+++ b/charts/influxdb3-core/templates/configmap.yaml
@@ -1,0 +1,254 @@
+{{- include "influxdb3-core.validateObjectStorageType" . }}
+{{- include "influxdb3-core.validateAzureObjectStorageAuth" . }}
+{{- include "influxdb3-core.validateS3ObjectStorageAuth" . }}
+{{- include "influxdb3-core.validateGoogleObjectStorageAuth" . }}
+{{- include "influxdb3-core.validateObjectStoreTlsCa" . }}
+{{- include "influxdb3-core.validateAdminTokenConfig" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "influxdb3-core.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+data:
+  # Security
+  {{- if .Values.security.tls.enabled }}
+  INFLUXDB3_TLS_CERT: {{ .Values.security.tls.certPath | quote }}
+  INFLUXDB3_TLS_KEY: {{ .Values.security.tls.keyPath | quote }}
+  INFLUXDB3_TLS_MINIMUM_VERSION: {{ .Values.security.tls.minVersion | quote }}
+  {{- end }}
+  {{- if .Values.security.auth.disabled }}
+  INFLUXDB3_START_WITHOUT_AUTH: {{ ternary "true" "false" .Values.security.auth.disabled | quote }}
+  {{- end }}
+  {{- if .Values.security.auth.disableAuthz }}
+  INFLUXDB3_DISABLE_AUTHZ: {{ join "," .Values.security.auth.disableAuthz | quote }}
+  {{- end }}
+  {{- $security := .Values.security | default dict }}
+  {{- $auth := get $security "auth" | default dict }}
+  {{- $adminToken := get $auth "adminToken" | default dict }}
+  {{- $adminTokenRecovery := get $adminToken "recovery" | default dict }}
+  {{- if get $adminTokenRecovery "httpBind" }}
+  INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND: {{ get $adminTokenRecovery "httpBind" | quote }}
+  {{- end }}
+
+  # HTTP
+  {{- with .Values.http }}
+  {{- if .bind }}
+  INFLUXDB3_HTTP_BIND_ADDR: {{ .bind | quote }}
+  {{- end }}
+  {{- if .maxRequestSize }}
+  INFLUXDB3_MAX_HTTP_REQUEST_SIZE: {{ .maxRequestSize | int | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Queries
+  {{- with .Values.queries }}
+  {{- if .fileLimit }}
+  INFLUXDB3_QUERY_FILE_LIMIT: {{ .fileLimit | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Object storage (non-secret)
+  INFLUXDB3_OBJECT_STORE: {{ .Values.objectStorage.type | quote }}
+  {{- if eq .Values.objectStorage.type "file" }}
+  INFLUXDB3_DB_DIR: {{ .Values.objectStorage.file.dataDir | quote }}
+  {{- else }}
+  INFLUXDB3_BUCKET: {{ .Values.objectStorage.bucket | quote }}
+  {{- end }}
+  {{- if .Values.objectStorage.connectionLimit }}
+  INFLUXDB3_OBJECT_STORE_CONNECTION_LIMIT: {{ .Values.objectStorage.connectionLimit | quote }}
+  {{- end }}
+  {{- if hasKey .Values.objectStorage "http2Only" }}
+  INFLUXDB3_OBJECT_STORE_HTTP2_ONLY: {{ ternary "true" "false" .Values.objectStorage.http2Only | quote }}
+  {{- end }}
+  {{- if .Values.objectStorage.http2MaxFrameSize }}
+  INFLUXDB3_OBJECT_STORE_HTTP2_MAX_FRAME_SIZE: {{ .Values.objectStorage.http2MaxFrameSize | quote }}
+  {{- end }}
+  {{- if .Values.objectStorage.requestTimeout }}
+  INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT: {{ .Values.objectStorage.requestTimeout | quote }}
+  {{- end }}
+  {{- if hasKey .Values.objectStorage "tlsAllowInsecure" }}
+  INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE: {{ ternary "true" "false" .Values.objectStorage.tlsAllowInsecure | quote }}
+  {{- end }}
+  {{- $tlsCa := .Values.objectStorage.tlsCa | default dict }}
+  {{- if get $tlsCa "certPath" }}
+  INFLUXDB3_OBJECT_STORE_TLS_CA: {{ get $tlsCa "certPath" | quote }}
+  {{- else if get $tlsCa "existingSecret" }}
+  INFLUXDB3_OBJECT_STORE_TLS_CA: "/etc/influxdb/object-store-ca/ca.crt"
+  {{- end }}
+  {{- if .Values.objectStorage.maxRetries }}
+  INFLUXDB3_OBJECT_STORE_MAX_RETRIES: {{ .Values.objectStorage.maxRetries | quote }}
+  {{- end }}
+  {{- if .Values.objectStorage.retryTimeout }}
+  INFLUXDB3_OBJECT_STORE_RETRY_TIMEOUT: {{ .Values.objectStorage.retryTimeout | quote }}
+  {{- end }}
+  {{- if .Values.objectStorage.cacheEndpoint }}
+  INFLUXDB3_OBJECT_STORE_CACHE_ENDPOINT: {{ .Values.objectStorage.cacheEndpoint | quote }}
+  {{- end }}
+  {{- if eq .Values.objectStorage.type "s3" }}
+  {{- $s3 := .Values.objectStorage.s3 | default dict }}
+  AWS_DEFAULT_REGION: {{ (get $s3 "region" | default "us-east-1") | quote }}
+  {{- if get $s3 "endpoint" }}
+  AWS_ENDPOINT: {{ get $s3 "endpoint" | quote }}
+  {{- end }}
+  {{- if get $s3 "allowHttp" }}
+  AWS_ALLOW_HTTP: "true"
+  {{- end }}
+  {{- if get $s3 "skipSignature" }}
+  AWS_SKIP_SIGNATURE: "true"
+  {{- end }}
+  {{- if get $s3 "credentialsFile" }}
+  AWS_CREDENTIALS_FILE: "/etc/influxdb/aws/credentials"
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.objectStorage.type "azure" }}
+  {{- with .Values.objectStorage.azure }}
+  {{- if .endpoint }}
+  AZURE_ENDPOINT: {{ .endpoint | quote }}
+  {{- end }}
+  {{- if .allowHttp }}
+  AZURE_ALLOW_HTTP: "true"
+  {{- end }}
+  {{- end }}
+  {{- end }}
+  {{- if eq .Values.objectStorage.type "google" }}
+  GOOGLE_SERVICE_ACCOUNT: "/var/secrets/google/service-account.json"
+  {{- end }}
+
+  # WAL configuration
+  {{- with .Values.wal }}
+  {{- if .flushInterval }}
+  INFLUXDB3_WAL_FLUSH_INTERVAL: {{ .flushInterval | quote }}
+  {{- end }}
+  {{- if .snapshotSize }}
+  INFLUXDB3_WAL_SNAPSHOT_SIZE: {{ .snapshotSize | quote }}
+  {{- end }}
+  {{- if .maxWriteBufferSize }}
+  INFLUXDB3_WAL_MAX_WRITE_BUFFER_SIZE: {{ .maxWriteBufferSize | quote }}
+  {{- end }}
+  {{- if .snapshotFilesToKeep }}
+  INFLUXDB3_NUM_WAL_FILES_TO_KEEP: {{ .snapshotFilesToKeep | quote }}
+  {{- end }}
+  {{- if hasKey . "replayFailOnError" }}
+  INFLUXDB3_WAL_REPLAY_FAIL_ON_ERROR: {{ ternary "true" "false" .replayFailOnError | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Memory tuning
+  {{- with .Values.memory }}
+  {{- if .execMemPoolBytes }}
+  INFLUXDB3_EXEC_MEM_POOL_BYTES: {{ .execMemPoolBytes | quote }}
+  {{- end }}
+  {{- if .forceSnapshotMemThreshold }}
+  INFLUXDB3_FORCE_SNAPSHOT_MEM_THRESHOLD: {{ .forceSnapshotMemThreshold | quote }}
+  {{- end }}
+  {{- end }}
+
+  # DataFusion configuration
+  {{- with .Values.datafusion }}
+  {{- if .numThreads }}
+  INFLUXDB3_DATAFUSION_NUM_THREADS: {{ .numThreads | quote }}
+  {{- end }}
+  {{- if .maxParquetFanout }}
+  INFLUXDB3_DATAFUSION_MAX_PARQUET_FANOUT: {{ .maxParquetFanout | quote }}
+  {{- end }}
+  {{- if .config }}
+  INFLUXDB3_DATAFUSION_CONFIG: {{ .config | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Caching configuration
+  {{- with .Values.caching }}
+  {{- if .parquetMemCacheSize }}
+  INFLUXDB3_PARQUET_MEM_CACHE_SIZE: {{ .parquetMemCacheSize | quote }}
+  {{- end }}
+  {{- if .lastCacheEvictionInterval }}
+  INFLUXDB3_LAST_CACHE_EVICTION_INTERVAL: {{ .lastCacheEvictionInterval | quote }}
+  {{- end }}
+  {{- if .distinctCacheEvictionInterval }}
+  INFLUXDB3_DISTINCT_CACHE_EVICTION_INTERVAL: {{ .distinctCacheEvictionInterval | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Data lifecycle
+  {{- with .Values.dataLifecycle }}
+  {{- if .gen1Duration }}
+  INFLUXDB3_GEN1_DURATION: {{ .gen1Duration | quote }}
+  {{- end }}
+  {{- if .retentionCheckInterval }}
+  INFLUXDB3_RETENTION_CHECK_INTERVAL: {{ .retentionCheckInterval | quote }}
+  {{- end }}
+  {{- if .deleteGracePeriod }}
+  INFLUXDB3_DELETE_GRACE_PERIOD: {{ .deleteGracePeriod | quote }}
+  {{- end }}
+  {{- if .hardDeleteDefaultDuration }}
+  INFLUXDB3_HARD_DELETE_DEFAULT_DURATION: {{ .hardDeleteDefaultDuration | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Processing engine
+  {{- if .Values.processingEngine.enabled }}
+  INFLUXDB3_PLUGIN_DIR: {{ .Values.processingEngine.pluginDir | default "/plugins" | quote }}
+  {{- if .Values.processingEngine.pluginRepo }}
+  INFLUXDB3_PLUGIN_REPO: {{ .Values.processingEngine.pluginRepo | quote }}
+  {{- end }}
+  {{- if .Values.processingEngine.packageManager }}
+  INFLUXDB3_PACKAGE_MANAGER: {{ .Values.processingEngine.packageManager | quote }}
+  {{- end }}
+  {{- if .Values.processingEngine.virtualEnvLocation }}
+  VIRTUAL_ENV: {{ .Values.processingEngine.virtualEnvLocation | quote }}
+  {{- end }}
+  {{- end }}
+
+  # Logs
+  {{- with .Values.logs }}
+  {{- if .logFilter }}
+  INFLUXDB3_LOG_FILTER: {{ .logFilter | quote }}
+  {{- end }}
+  {{- if .logDestination }}
+  INFLUXDB3_LOG_DESTINATION: {{ .logDestination | quote }}
+  {{- end }}
+  {{- if .logFormat }}
+  INFLUXDB3_LOG_FORMAT: {{ .logFormat | quote }}
+  {{- end }}
+  {{- if .queryLogSize }}
+  INFLUXDB3_QUERY_LOG_SIZE: {{ .queryLogSize }}
+  {{- end }}
+  {{- end }}
+
+  # Tracing
+  {{- with .Values.traces }}
+  INFLUXDB3_TRACES_EXPORTER: {{ .exporter | quote }}
+  {{- with .jaeger }}
+  {{- if .agentHost }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_HOST: {{ .agentHost | quote }}
+  {{- end }}
+  {{- if .agentPort }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_PORT: {{ .agentPort | quote }}
+  {{- end }}
+  {{- if .serviceName }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_SERVICE_NAME: {{ .serviceName | quote }}
+  {{- end }}
+  {{- if .traceContextHeaderName }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME: {{ .traceContextHeaderName | quote }}
+  {{- end }}
+  {{- if .debugName }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME: {{ .debugName | quote }}
+  {{- end }}
+  {{- if .tags }}
+  INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS: {{ .tags | quote }}
+  {{- end }}
+  {{- if .maxMsgsPerSecond }}
+  INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND: {{ .maxMsgsPerSecond | quote }}
+  {{- end }}
+  {{- end }}
+  {{- end }}
+
+  # Telemetry
+  {{- with .Values.telemetry }}
+  INFLUXDB3_TELEMETRY_DISABLE_UPLOAD: {{ .disableUpload | quote }}
+  {{- if .endpoint }}
+  INFLUXDB3_TELEMETRY_ENDPOINT: {{ .endpoint | quote }}
+  {{- end }}
+  {{- end }}

--- a/charts/influxdb3-core/templates/ingress.yaml
+++ b/charts/influxdb3-core/templates/ingress.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "influxdb3-core.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "influxdb3-core.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/influxdb3-core/templates/networkpolicy.yaml
+++ b/charts/influxdb3-core/templates/networkpolicy.yaml
@@ -1,0 +1,116 @@
+# Network Policy to secure communication to and from InfluxDB 3 Core
+#
+# To enable: set networkPolicy.enabled: true in values.yaml
+#
+# IMPORTANT: Requires a CNI plugin that supports NetworkPolicy
+# (e.g., Calico, Cilium, Weave Net, or Antrea)
+#
+# If your cluster doesn't support NetworkPolicy, keep this disabled
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "influxdb3-core.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "influxdb3-core.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
+  ingress:
+    # Allow traffic from ingress controller
+    {{- if .Values.networkPolicy.ingress.fromIngressController }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.ingress.ingressController.namespaceLabel }}: {{ .Values.networkPolicy.ingress.ingressController.namespace }}
+          podSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.ingress.ingressController.podLabelKey }}: {{ .Values.networkPolicy.ingress.ingressController.podLabelValue }}
+      ports:
+        - protocol: TCP
+          port: 8181
+    {{- end }}
+    # Allow Prometheus to scrape metrics
+    {{- if .Values.networkPolicy.ingress.fromPrometheus }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.ingress.prometheus.namespaceLabel }}: {{ .Values.networkPolicy.ingress.prometheus.namespace }}
+          podSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.ingress.prometheus.podLabelKey }}: {{ .Values.networkPolicy.ingress.prometheus.podLabelValue }}
+      ports:
+        - protocol: TCP
+          port: 8181
+    {{- end }}
+  egress:
+    # Allow DNS resolution
+    {{- if .Values.networkPolicy.egress.toDns }}
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.egress.dns.namespaceLabel }}: {{ .Values.networkPolicy.egress.dns.namespace }}
+          podSelector:
+            matchLabels:
+              {{ .Values.networkPolicy.egress.dns.podLabelKey }}: {{ .Values.networkPolicy.egress.dns.podLabelValue }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- end }}
+    # Allow access to object storage
+    {{- if .Values.networkPolicy.egress.toObjectStorage }}
+    {{- if .Values.networkPolicy.egress.objectStorageCidrs }}
+    # Egress to specific object storage CIDRs (AWS S3, Azure, GCS endpoints)
+    {{- range .Values.networkPolicy.egress.objectStorageCidrs }}
+    - to:
+        - ipBlock:
+            cidr: {{ . }}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- else }}
+    # Default: Allow egress to any destination for object storage
+    # WARNING: This is permissive. Configure objectStorageCidrs for production.
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 9000  # MinIO default
+    {{- end }}
+    {{- end }}
+    # Allow outbound HTTP/HTTPS for plugin operations (webhooks, notifications, etc.)
+    {{- if and .Values.processingEngine.enabled .Values.networkPolicy.egress.toPluginEndpoints }}
+    {{- if .Values.networkPolicy.egress.pluginEndpointCidrs }}
+    # Egress to specific plugin endpoint CIDRs
+    {{- range .Values.networkPolicy.egress.pluginEndpointCidrs }}
+    - to:
+        - ipBlock:
+            cidr: {{ . }}
+      ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- else }}
+    # Default: Allow egress to any destination for plugin operations
+    # WARNING: This is permissive. Configure pluginEndpointCidrs for production.
+    - ports:
+        - protocol: TCP
+          port: 443
+        - protocol: TCP
+          port: 80
+    {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/influxdb3-core/templates/secret-object-storage.yaml
+++ b/charts/influxdb3-core/templates/secret-object-storage.yaml
@@ -1,0 +1,80 @@
+{{- $type := .Values.objectStorage.type | default "file" }}
+{{- $s3 := .Values.objectStorage.s3 | default dict }}
+{{- $s3ExistingSecret := get $s3 "existingSecret" | default "" }}
+{{- $s3AccessKeyID := get $s3 "accessKeyId" | default "" }}
+{{- $s3SecretAccessKey := get $s3 "secretAccessKey" | default "" }}
+{{- $s3SessionToken := get $s3 "sessionToken" | default "" }}
+{{- $s3CredentialsFile := get $s3 "credentialsFile" | default "" }}
+{{- $s3HasAccessPair := and $s3AccessKeyID $s3SecretAccessKey }}
+{{- $s3SecretCreds := or $s3HasAccessPair $s3SessionToken }}
+{{- $azure := .Values.objectStorage.azure | default dict }}
+{{- $azureExistingSecret := get $azure "existingSecret" | default "" }}
+{{- $azureStorageAccount := get $azure "storageAccount" | default "" }}
+{{- $azureAccessKey := get $azure "accessKey" | default "" }}
+{{- $azureCreds := and $azureStorageAccount $azureAccessKey }}
+{{- $google := .Values.objectStorage.google | default dict }}
+{{- $googleExistingSecret := get $google "existingSecret" | default "" }}
+{{- $googleServiceAccountJSON := get $google "serviceAccountJson" | default "" }}
+{{- $googleCreds := $googleServiceAccountJSON }}
+
+{{- if and (eq $type "s3") (not $s3ExistingSecret) $s3SecretCreds }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "influxdb3-core.objectStorageSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if $s3AccessKeyID }}
+  access-key-id: {{ $s3AccessKeyID | b64enc | quote }}
+  {{- end }}
+  {{- if $s3SecretAccessKey }}
+  secret-access-key: {{ $s3SecretAccessKey | b64enc | quote }}
+  {{- end }}
+  {{- if $s3SessionToken }}
+  session-token: {{ $s3SessionToken | b64enc | quote }}
+  {{- end }}
+{{- else if and (eq $type "azure") (not $azureExistingSecret) $azureCreds }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "influxdb3-core.objectStorageSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if $azureStorageAccount }}
+  storage-account: {{ $azureStorageAccount | b64enc | quote }}
+  {{- end }}
+  {{- if $azureAccessKey }}
+  access-key: {{ $azureAccessKey | b64enc | quote }}
+  {{- end }}
+{{- else if and (eq $type "google") (not $googleExistingSecret) $googleCreds }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "influxdb3-core.objectStorageSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+type: Opaque
+data:
+  service-account.json: {{ $googleServiceAccountJSON | b64enc | quote }}
+{{- end }}
+
+{{- if and (eq $type "s3") $s3CredentialsFile }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "influxdb3-core.fullname" . }}-aws-credentials
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+type: Opaque
+data:
+  credentials: {{ $s3CredentialsFile | b64enc | quote }}
+{{- end }}

--- a/charts/influxdb3-core/templates/secret-tls.yaml
+++ b/charts/influxdb3-core/templates/secret-tls.yaml
@@ -1,0 +1,16 @@
+{{- if and .Values.security.tls.enabled (not .Values.security.tls.existingSecret) }}
+{{- if not (and .Values.security.tls.cert .Values.security.tls.key) }}
+{{- fail "TLS is enabled but tls.cert/tls.key are not provided and tls.existingSecret is not set." }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "influxdb3-core.tlsSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+type: kubernetes.io/tls
+data:
+  tls.crt: {{ .Values.security.tls.cert | b64enc | quote }}
+  tls.key: {{ .Values.security.tls.key | b64enc | quote }}
+{{- end }}

--- a/charts/influxdb3-core/templates/service.yaml
+++ b/charts/influxdb3-core/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "influxdb3-core.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "influxdb3-core.selectorLabels" . | nindent 4 }}

--- a/charts/influxdb3-core/templates/serviceaccount.yaml
+++ b/charts/influxdb3-core/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "influxdb3-core.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/influxdb3-core/templates/servicemonitor.yaml
+++ b/charts/influxdb3-core/templates/servicemonitor.yaml
@@ -1,0 +1,30 @@
+# ServiceMonitor for Prometheus Operator
+#
+# To enable: set serviceMonitor.enabled: true in values.yaml
+#
+# IMPORTANT: Requires Prometheus Operator to be installed in the cluster
+# See: https://github.com/prometheus-operator/prometheus-operator
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "influxdb3-core.fullname" . }}
+  namespace: {{ .Values.serviceMonitor.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+    {{- with .Values.serviceMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "influxdb3-core.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  endpoints:
+    - port: http
+      path: /metrics
+      interval: {{ .Values.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/charts/influxdb3-core/templates/statefulset.yaml
+++ b/charts/influxdb3-core/templates/statefulset.yaml
@@ -1,0 +1,184 @@
+{{- $filePersistenceEnabled := and (eq .Values.objectStorage.type "file") .Values.objectStorage.file.persistence.enabled }}
+{{- $pluginsPersistenceEnabled := and .Values.processingEngine.enabled .Values.processingEngine.persistence.enabled }}
+{{- $pluginDir := .Values.processingEngine.pluginDir | default "/plugins" }}
+{{- $objectStoreSecretEnv := include "influxdb3-core.objectStoreSecretEnv" . | trim }}
+{{- $adminTokenEnv := include "influxdb3-core.adminTokenEnv" . | trim }}
+{{- $sharedVolumeMounts := include "influxdb3-core.sharedVolumeMounts" . | trim }}
+{{- $adminTokenVolumeMounts := include "influxdb3-core.adminTokenVolumeMounts" . | trim }}
+{{- $sharedVolumes := include "influxdb3-core.sharedVolumes" . | trim }}
+{{- $adminTokenVolumes := include "influxdb3-core.adminTokenVolumes" . | trim }}
+{{- $dataEmptyDir := and (eq .Values.objectStorage.type "file") (not $filePersistenceEnabled) }}
+{{- $pluginsEmptyDir := and .Values.processingEngine.enabled (not $pluginsPersistenceEnabled) }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "influxdb3-core.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "influxdb3-core.fullname" . }}
+  # InfluxDB 3 Core is a single-node database - do not scale this up
+  replicas: 1
+  {{- if .Values.updateStrategy }}
+  updateStrategy:
+    {{- toYaml .Values.updateStrategy | nindent 4 }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "influxdb3-core.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret-object-storage.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "influxdb3-core.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if and .Values.processingEngine.enabled .Values.processingEngine.initPlugins (gt (len .Values.processingEngine.initPlugins) 0) }}
+      initContainers:
+        {{- range .Values.processingEngine.initPlugins }}
+        - name: init-plugin-{{ .name | default "plugin" | replace "." "-" | replace "_" "-" | trunc 51 | trimSuffix "-" }}
+          image: {{ include "influxdb3-core.image" $ }}
+          imagePullPolicy: {{ $.Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - >
+              influxdb3 install package {{ .name | quote }}{{- if .source }} --source {{ .source | quote }}{{- end }} --plugin-dir {{ $pluginDir | quote }}
+          volumeMounts:
+            - name: plugins
+              mountPath: {{ $pluginDir }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "influxdb3-core.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: influxdb3
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "influxdb3-core.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              exec influxdb3 \
+                {{- with .Values.numIOThreads }}
+                --num-io-threads={{ . }} \
+                {{- end }}
+                serve \
+                --node-id={{ .Values.node.id | default "$(hostname)" }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "influxdb3-core.fullname" . }}-config
+          {{- if or $objectStoreSecretEnv $adminTokenEnv .Values.extraEnv }}
+          env:
+            {{- with $objectStoreSecretEnv }}
+            {{- . | nindent 12 }}
+            {{- end }}
+            {{- with $adminTokenEnv }}
+            {{- . | nindent 12 }}
+            {{- end }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8181
+              protocol: TCP
+          {{- include "influxdb3-core.probes" . | nindent 10 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or (eq .Values.objectStorage.type "file") .Values.processingEngine.enabled $sharedVolumeMounts $adminTokenVolumeMounts }}
+          volumeMounts:
+            {{- if eq .Values.objectStorage.type "file" }}
+            - name: data
+              mountPath: {{ .Values.objectStorage.file.dataDir }}
+            {{- end }}
+            {{- if .Values.processingEngine.enabled }}
+            - name: plugins
+              mountPath: {{ $pluginDir }}
+            {{- end }}
+            {{- with $sharedVolumeMounts }}
+            {{- . | nindent 12 }}
+            {{- end }}
+            {{- with $adminTokenVolumeMounts }}
+            {{- . | nindent 12 }}
+            {{- end }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if or $dataEmptyDir $pluginsEmptyDir $sharedVolumes $adminTokenVolumes }}
+      volumes:
+        {{- if $dataEmptyDir }}
+        - name: data
+          emptyDir: {}
+        {{- end }}
+        {{- if $pluginsEmptyDir }}
+        - name: plugins
+          emptyDir: {}
+        {{- end }}
+        {{- with $sharedVolumes }}
+        {{- . | nindent 8 }}
+        {{- end }}
+        {{- with $adminTokenVolumes }}
+        {{- . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+  {{- if or $filePersistenceEnabled $pluginsPersistenceEnabled }}
+  volumeClaimTemplates:
+    {{- if $filePersistenceEnabled }}
+    - metadata:
+        name: data
+      spec:
+        accessModes:
+          - {{ .Values.objectStorage.file.persistence.accessMode }}
+      {{- if .Values.objectStorage.file.persistence.storageClass }}
+        storageClassName: {{ .Values.objectStorage.file.persistence.storageClass | quote }}
+      {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.objectStorage.file.persistence.size }}
+    {{- end }}
+    {{- if $pluginsPersistenceEnabled }}
+    - metadata:
+        name: plugins
+      spec:
+        accessModes:
+          - {{ .Values.processingEngine.persistence.accessMode }}
+      {{- if .Values.processingEngine.persistence.storageClass }}
+        storageClassName: {{ .Values.processingEngine.persistence.storageClass | quote }}
+      {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.processingEngine.persistence.size }}
+    {{- end }}
+  {{- end }}

--- a/charts/influxdb3-core/values.yaml
+++ b/charts/influxdb3-core/values.yaml
@@ -1,0 +1,496 @@
+# ============================================================================
+# Kubernetes Configuration
+# ============================================================================
+
+# Naming overrides
+nameOverride: ""
+fullnameOverride: ""
+
+# Image configuration
+image:
+  registry: docker.io
+  repository: influxdb
+  # -- Optional explicit tag override. If empty, defaults to "<appVersion>-core".
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+# - name: registry-secret
+
+# ============================================================================
+# Node Configuration
+# ============================================================================
+# InfluxDB 3 Core is a single-node database. The chart always deploys exactly
+# one replica.
+
+node:
+  # -- Node identifier, must be unique among hosts sharing the same object
+  # store. If empty, the pod hostname is used (stable for a StatefulSet).
+  id: ""
+
+# ============================================================================
+# Object Storage Configuration
+# ============================================================================
+# InfluxDB 3 Core persists data as Parquet files in an object store.
+
+objectStorage:
+  # -- Object store type: file, s3, azure, google, memory, memory-throttled
+  type: file
+
+  # -- Bucket/container name for storing data (s3, azure, google)
+  bucket: "influxdb3-core-data"
+
+  # Connection settings
+  # connectionLimit: 16             # Max connections to object store (doc default 16)
+  # http2Only: false                # Force HTTP/2 connections (optional)
+  # http2MaxFrameSize: ""           # HTTP/2 max frame size (optional)
+  # requestTimeout: ""              # Object store request timeout (optional, server default: 30s)
+  # maxRetries: ""                  # Object store retry attempts (optional)
+  # retryTimeout: ""                # Object store retry timeout (optional)
+  # cacheEndpoint: ""               # Object store cache endpoint (optional)
+  # tlsAllowInsecure: false         # Skip object-store TLS cert verification (testing only)
+  # tlsCa:
+  #   certPath: ""                  # Path to custom CA PEM file for object-store TLS verification
+  #   existingSecret: ""            # Alternative to certPath; secret with key "ca.crt"
+  # NOTE: set only one of tlsCa.certPath or tlsCa.existingSecret
+
+  # Local filesystem storage (default)
+  # Data is stored on a PersistentVolumeClaim mounted into the pod
+  file:
+    dataDir: "/var/lib/influxdb3"
+    persistence:
+      # -- Create a PVC for the data directory. When disabled, an emptyDir is
+      # used and all data is lost when the pod restarts.
+      enabled: true
+      storageClass: ""
+      size: 50Gi
+      accessMode: ReadWriteOnce
+
+  # S3 and S3-compatible storage (MinIO, etc.)
+  # To use S3, set objectStorage.type: s3
+  s3:
+    # AWS region (required for AWS S3)
+    region: "us-east-1"
+    # S3 endpoint URL (leave empty for AWS, set for S3-compatible like MinIO)
+    # Examples:
+    #   AWS: "" (uses default regional endpoint)
+    #   MinIO: "http://minio.minio.svc.cluster.local:9000"
+    endpoint: ""
+    # Access credentials
+    accessKeyId: ""
+    secretAccessKey: ""
+    sessionToken: ""                # Optional, for federated/SSO
+    # AWS JSON credentials file content (alternative to accessKeyId/secretAccessKey)
+    # Use: helm install ... --set-file objectStorage.s3.credentialsFile=/path/to/credentials.json
+    credentialsFile: ""
+    # Connection options
+    # allowHttp: false                # Set true for HTTP (non-TLS) connections
+    # skipSignature: false            # Skip request signing (not recommended)
+
+    # Existing secret (alternative to specifying credentials here)
+    # If specified, the chart will use this secret instead of creating one
+    # Secret should contain keys: access-key-id, secret-access-key
+    existingSecret: ""
+
+  # Azure Blob Storage
+  # To use Azure, set objectStorage.type: azure
+  azure:
+    # Storage account name (visible in Azure portal under "All Services > Storage accounts")
+    storageAccount: ""
+    # Access key (from Storage account's "Settings > Access keys")
+    accessKey: ""
+    # Optional: Azure Blob Storage endpoint URL (auto-determined if not set)
+    endpoint: ""
+    # Optional: Allow HTTP (non-TLS) connections
+    allowHttp: false
+    # Existing secret (alternative to specifying credentials here)
+    # If specified, the chart will use this secret instead of creating one
+    # Secret should contain keys: storage-account, access-key
+    existingSecret: ""
+
+  # Google Cloud Storage
+  # To use GCS, set objectStorage.type: google
+  google:
+    # Service account JSON credentials (full JSON content as string)
+    # This will be mounted as a file at /var/secrets/google/service-account.json
+    serviceAccountJson: ""
+    # Existing secret (alternative to specifying credentials here)
+    # If specified, the chart will use this secret instead of creating one
+    # Secret should contain key: service-account.json
+    existingSecret: ""
+
+  # In-memory storage (no persistence)
+  # memory:
+
+  # In-memory storage (no persistence) but with latency and throughput that somewhat resembles a cloud object store
+  # memory-throttled:
+
+# ============================================================================
+# Server Deployment Configuration
+# ============================================================================
+
+# Resource allocation
+resources: {}
+# resources:
+#   requests:
+#     cpu: "1000m"
+#     memory: "2Gi"
+#   limits:
+#     cpu: "2000m"
+#     memory: "4Gi"
+
+# Thread configuration
+# numIOThreads: 2             # Global IO threads (--num-io-threads)
+
+# Memory tuning
+# memory:
+#   execMemPoolBytes: "20%"            # --exec-mem-pool-bytes
+#   forceSnapshotMemThreshold: "50%"   # --force-snapshot-mem-threshold
+
+# DataFusion configuration
+# datafusion:
+#   numThreads: 16                # --datafusion-num-threads
+#   maxParquetFanout: 1000        # --datafusion-max-parquet-fanout
+#   config: ""                    # --datafusion-config (key:value pairs)
+
+# Write-Ahead Log (WAL) configuration
+# wal:
+#   flushInterval: "1s"               # How often to flush WAL
+#   snapshotSize: 600                 # WAL files per snapshot
+#   maxWriteBufferSize: 100000        # Max buffered writes before flush
+#   snapshotFilesToKeep: 300          # Snapshotted WAL files to retain
+#   replayFailOnError: false
+
+# Pod affinity/anti-affinity, node selectors, tolerations
+affinity: {}
+nodeSelector: {}
+tolerations: []
+
+# Additional pod annotations and labels
+podAnnotations: {}
+podLabels: {}
+
+# Security context
+# InfluxDB3 runs as uid=1500(influxdb3) gid=1500(influxdb3)
+podSecurityContext:
+  fsGroup: 1500              # Ensures volumes are owned by influxdb3 group
+  runAsNonRoot: true         # Security best practice
+  runAsUser: 1500            # Run as influxdb3 user
+  runAsGroup: 1500           # Run as influxdb3 group
+
+# Container-level security context (optional override)
+securityContext: {}
+
+# Service configuration
+service:
+  type: ClusterIP
+  port: 8181
+  annotations: {}
+
+# Priority class for pod scheduling priority
+# Higher priority pods are scheduled before lower priority pods
+# Use "system-cluster-critical" or "system-node-critical" for critical workloads
+priorityClassName: ""
+
+# Update strategy for rolling updates
+updateStrategy:
+  type: RollingUpdate
+
+# ============================================================================
+# Processing Engine (optional)
+# ============================================================================
+# Embedded Python VM for plugins and triggers.
+# NOTE: enabling this after the initial install adds a volumeClaimTemplate to
+# the StatefulSet, which requires recreating it:
+#   kubectl delete statefulset <release-fullname> --cascade=orphan
+
+processingEngine:
+  enabled: false
+
+  # -- Local directory that contains Python plugins and their test files (--plugin-dir)
+  pluginDir: "/plugins"
+  # pluginRepo: "https://raw.githubusercontent.com/influxdata/influxdb3_plugins/main/"  # URL of remote plugin repository
+  # packageManager: "discover"        # discover, pip, uv, or disabled
+  # virtualEnvLocation: ""            # VIRTUAL_ENV override (optional)
+
+  # Persistent storage for plugins
+  persistence:
+    enabled: true
+    storageClass: ""
+    size: "5Gi"
+    accessMode: ReadWriteOnce
+
+  # Pre-install plugins via initContainer (optional)
+  initPlugins: []
+    # - name: system-metrics
+    #   source: "gh:influxdata/system_metrics/system_metrics.py"
+
+# ============================================================================
+# Advanced Configuration
+# ============================================================================
+
+# Security configuration (TLS and auth)
+security:
+  tls:
+    enabled: false
+    # Inline cert/key (used only when existingSecret is not set)
+    cert: ""
+    key: ""
+    # Paths to certificate and key files (mounted via secrets)
+    certPath: "/etc/influxdb/tls/tls.crt"
+    keyPath: "/etc/influxdb/tls/tls.key"
+    minVersion: "tls-1.2"             # tls-1.2 or tls-1.3
+    # Existing secret containing TLS cert/key
+    # Secret should contain keys: tls.crt, tls.key
+    existingSecret: ""
+
+  auth:
+    # Disable authentication (dev/testing only - NOT RECOMMENDED)
+    disabled: false
+    # Disable authorization for specific endpoints
+    # Default: ["health"] - allows Kubernetes probes without authentication
+    # Available endpoints: health, ping, metrics
+    # Set to [] to require authentication for all endpoints
+    disableAuthz: ["health"]
+    # Existing secret containing an offline preconfigured admin token JSON.
+    # Secret must contain key: admin-token.json
+    # Set only one of adminToken.existingSecret or adminToken.file.
+    adminToken:
+      existingSecret: ""
+      file: ""
+      # Admin token recovery configuration
+      # recovery:
+      #   httpBind: "127.0.0.1:8182"     # Recovery bind address when enabled (doc default)
+
+# HTTP server configuration
+http:
+  # bind: "0.0.0.0:8181"
+  # maxRequestSize: 10485760          # 10MB default
+
+# Query configuration
+# queries:
+#   fileLimit: 432                    # Max Parquet files per query (--query-file-limit, default 432)
+
+# Caching configuration
+caching:
+  # Parquet file caching
+  # parquetMemCacheSize: "20%"        # Or absolute like "4096" (MB)
+
+  # Last value cache
+  # lastCacheEvictionInterval: "10s"
+
+  # Distinct value cache
+  # distinctCacheEvictionInterval: "10s"
+
+# Data lifecycle management
+# dataLifecycle:
+#   gen1Duration: "10m"               # Duration of gen1 Parquet files (--gen1-duration)
+#   retentionCheckInterval: "30m"     # How often to check retention policies
+#   deleteGracePeriod: "24h"          # Grace period before permanent deletion
+#   hardDeleteDefaultDuration: "90d"  # Default hard delete duration
+
+# Logs configuration
+# logs:
+#   logFilter: ""                     # Override log filter (--log-filter)
+#   logDestination: "stdout"          # Override log destination (--log-destination)
+#   logFormat: "full"                 # Override log format (--log-format)
+#   queryLogSize: 1000                # Query log size (--query-log-size)
+
+# Traces configuration (optional)
+# traces:
+#  exporter: "none"                # jaeger or none
+#  jaeger:
+#    agentHost: "0.0.0.0"
+#    agentPort: 6831
+#    serviceName: "influxdb3-core"
+#    traceContextHeaderName: "uber-trace-id"
+#    debugName: "jaeger-debug-id"
+#    tags: ""
+#    maxMsgsPerSecond: 1000
+
+# Telemetry
+# telemetry:
+#   disableUpload: false              # Set true to opt-out of InfluxData telemetry
+#   endpoint: ""                      # Custom telemetry endpoint
+
+# ============================================================================
+# Probes Configuration
+# ============================================================================
+# Note: /health endpoint authentication is disabled by default (auth.disableAuthz: ["health"])
+# so probes work without requiring tokens
+probes:
+  # Enable or disable health probes globally
+  enabled: true
+
+  # Startup probe settings
+  # Protects container during initialization. Once successful, never runs again.
+  # For ~15s startup: 10s initial + (12 × 5s) = 70s total (4-5x safety buffer)
+  startup:
+    initialDelaySeconds: 10           # Wait ~50% of expected startup time
+    periodSeconds: 5                  # Check every 5 seconds
+    timeoutSeconds: 5
+    failureThreshold: 12              # 10s + (12 × 5s) = 70s total
+
+  # Liveness probe settings
+  # Only starts checking AFTER startup probe succeeds
+  liveness:
+    initialDelaySeconds: 0            # No delay needed - startup probe protects
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3               # 3 × 10s = 30s before restart
+
+  # Readiness probe settings
+  # Only starts checking AFTER startup probe succeeds
+  readiness:
+    initialDelaySeconds: 0            # No delay needed - startup probe protects
+    periodSeconds: 5                  # Check frequently
+    timeoutSeconds: 3
+    failureThreshold: 3
+
+# ============================================================================
+# Ingress Configuration
+# ============================================================================
+# Single ingress routing all traffic (write and query) to the server
+
+ingress:
+  enabled: false
+
+  # Host for the ingress
+  host: "influxdb.example.com"
+
+  # Ingress class name
+  className: ""
+
+  # Annotations for the ingress
+  annotations: {}
+  # annotations:
+  #   nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+  #   nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
+  # TLS configuration
+  tls: []
+  # tls:
+  #   - secretName: influxdb-tls
+  #     hosts:
+  #       - influxdb.example.com
+
+# ============================================================================
+# Network Policies (optional, disabled by default)
+# ============================================================================
+# To enable network policies, set networkPolicy.enabled: true
+# NOTE: Requires a CNI plugin that supports NetworkPolicy (e.g., Calico, Cilium)
+
+networkPolicy:
+  enabled: false
+  # Policy type
+  policyTypes:
+    - Ingress
+    - Egress
+
+  # Ingress rules
+  ingress:
+    # Allow ingress controller to reach the server
+    fromIngressController: true
+    # Ingress controller configuration (cluster-specific)
+    ingressController:
+      # Namespace where ingress controller runs
+      namespace: ingress-nginx
+      # Namespace label selector (use kubernetes.io/metadata.name for standard k8s namespaces)
+      namespaceLabel: kubernetes.io/metadata.name
+      # Pod label selector for ingress controller pods
+      podLabelKey: app.kubernetes.io/name
+      podLabelValue: ingress-nginx
+      # Common alternatives:
+      #   NGINX Ingress: app.kubernetes.io/name: ingress-nginx (default)
+      #   Traefik: app.kubernetes.io/name: traefik
+      #   HAProxy: app.kubernetes.io/name: haproxy-ingress
+    # Allow Prometheus to scrape metrics (for cross-namespace monitoring)
+    fromPrometheus: false
+    # Prometheus configuration (cluster-specific)
+    prometheus:
+      # Namespace where Prometheus runs
+      namespace: monitoring
+      # Namespace label selector (use kubernetes.io/metadata.name for standard k8s namespaces)
+      namespaceLabel: kubernetes.io/metadata.name
+      # Pod label selector for Prometheus pods
+      podLabelKey: app.kubernetes.io/name
+      podLabelValue: prometheus
+
+  # Egress rules
+  egress:
+    # Allow DNS resolution
+    toDns: true
+    # DNS configuration (cluster-specific)
+    dns:
+      # Namespace where DNS service runs
+      namespace: kube-system
+      # Namespace label selector (use kubernetes.io/metadata.name for standard k8s namespaces)
+      namespaceLabel: kubernetes.io/metadata.name
+      # Pod label selector for DNS pods
+      podLabelKey: k8s-app
+      podLabelValue: kube-dns
+
+    # Allow access to object storage (only relevant for remote object stores)
+    toObjectStorage: true
+    # Optional: Specify CIDR blocks for object storage endpoints (recommended for production)
+    # If not set, allows egress to any destination on ports 443/80/9000 (permissive)
+    objectStorageCidrs: []
+    # - "52.216.0.0/15"
+    # - "54.231.0.0/16"
+
+    # Allow outbound HTTP/HTTPS for plugin operations (processing engine only)
+    # Enables plugins to call external webhooks, APIs, notification services, etc.
+    toPluginEndpoints: true
+    # Optional: Specify CIDR blocks for plugin endpoints (recommended for production)
+    # If not set, allows egress to any destination on ports 443/80 (permissive)
+    pluginEndpointCidrs: []
+    # - "192.0.2.0/24"
+
+# ============================================================================
+# Monitoring (optional, disabled by default)
+# ============================================================================
+
+serviceMonitor:
+  enabled: false
+  # Namespace where ServiceMonitor will be created (defaults to release namespace)
+  namespace: ""
+  # Scrape interval
+  interval: 30s
+  # Scrape timeout
+  scrapeTimeout: 10s
+  # Additional labels for ServiceMonitor (for Prometheus operator selector)
+  additionalLabels: {}
+  # prometheus: kube-prometheus
+
+# ============================================================================
+# Service Account
+# ============================================================================
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+# ============================================================================
+# Additional Configuration
+# ============================================================================
+
+# Extra environment variables
+extraEnv: []
+  # - name: CUSTOM_VAR
+#   value: "custom-value"
+
+# Extra volumes
+extraVolumes: []
+  # - name: custom-config
+  #   configMap:
+#     name: custom-config
+
+# Extra volume mounts
+extraVolumeMounts: []
+  # - name: custom-config
+#   mountPath: /etc/custom


### PR DESCRIPTION
## Summary

New `influxdb3-core` chart (version 0.1.0, appVersion 3.9.3) for deploying [InfluxDB 3 Core](https://docs.influxdata.com/influxdb3/core/) — the open source, single-node release of InfluxDB 3.

The chart follows the conventions of the upstream [influxdata/helm-charts](https://github.com/influxdata/helm-charts) `influxdb3-enterprise` chart (values layout, helpers, validations, env-var based config), with all Enterprise-only features removed (license, cluster id, node modes, permission tokens, compaction tuning) so it could later be proposed upstream.

## Details

- Single-replica StatefulSet running `influxdb3 serve --node-id=$(hostname)` (image `influxdb:<appVersion>-core`)
- Object storage: `file` (default, PVC via volumeClaimTemplates), `s3`, `azure`, `google`, `memory`, `memory-throttled`
- Token auth enabled by default; `/health` exempted so probes work; optional preconfigured admin-token secret; optional TLS
- Optional processing engine (Python plugins) with plugins PVC and `influxdb3 install package` init containers
- Optional ingress, NetworkPolicy, ServiceMonitor
- All exposed options verified against the [InfluxDB 3 Core config reference](https://docs.influxdata.com/influxdb3/core/reference/config-options/)
- `README.md` generated from `README.md.gotmpl` with helm-docs v1.14.2 (same as CI)

## Testing

- `helm lint`: pass
- `helm template` across 5 scenarios (default, s3+ingress+TLS+plugins+monitoring+netpol, memory, persistence disabled, invalid azure config → fails with clear message)
- Rendered manifests validated with `kubeconform -strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)