### PR TITLE
influxdb3-core 0.1.1: support binding data PVC to existing PV

### DIFF
--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-core
 description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -121,6 +121,7 @@ kubectl delete statefulset <release-name>-influxdb3-core --cascade=orphan
 | objectStorage.file.persistence.enabled | bool | `true` | Create a PVC for the data directory. When disabled, an emptyDir is used and all data is lost when the pod restarts. |
 | objectStorage.file.persistence.size | string | `"50Gi"` |  |
 | objectStorage.file.persistence.storageClass | string | `""` |  |
+| objectStorage.file.persistence.volumeName | string | `""` | Bind the data PVC to a specific PersistentVolume (e.g. a pre-created static PV) |
 | objectStorage.google.existingSecret | string | `""` |  |
 | objectStorage.google.serviceAccountJson | string | `""` |  |
 | objectStorage.s3.accessKeyId | string | `""` |  |

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -1,6 +1,6 @@
 # influxdb3-core
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
 
 A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 

--- a/charts/influxdb3-core/templates/statefulset.yaml
+++ b/charts/influxdb3-core/templates/statefulset.yaml
@@ -164,6 +164,9 @@ spec:
       {{- if .Values.objectStorage.file.persistence.storageClass }}
         storageClassName: {{ .Values.objectStorage.file.persistence.storageClass | quote }}
       {{- end }}
+      {{- if .Values.objectStorage.file.persistence.volumeName }}
+        volumeName: {{ .Values.objectStorage.file.persistence.volumeName | quote }}
+      {{- end }}
         resources:
           requests:
             storage: {{ .Values.objectStorage.file.persistence.size }}

--- a/charts/influxdb3-core/values.yaml
+++ b/charts/influxdb3-core/values.yaml
@@ -65,6 +65,8 @@ objectStorage:
       storageClass: ""
       size: 50Gi
       accessMode: ReadWriteOnce
+      # -- Bind the data PVC to a specific PersistentVolume (e.g. a pre-created static PV)
+      volumeName: ""
 
   # S3 and S3-compatible storage (MinIO, etc.)
   # To use S3, set objectStorage.type: s3


### PR DESCRIPTION
Adds `objectStorage.file.persistence.volumeName` so the data volumeClaimTemplate can bind to a pre-created static PV (NFS etc.). Needed for homelab deployment with static NAS PVs.

Commit landed on the feature branch just after #68 was merged, so it missed the 0.1.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)