### PR TITLE
influxdb3-core 0.2.0: optional InfluxDB 3 Explorer web UI

### DIFF
--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-core
 description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 type: application
-version: 0.1.1
+version: 0.2.0
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-core
 description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -1,6 +1,6 @@
 # influxdb3-core
 
-![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
 
 A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 
@@ -64,12 +64,70 @@ Note: enabling the processing engine after the initial install adds a volumeClai
 kubectl delete statefulset <release-name>-influxdb3-core --cascade=orphan
 ```
 
+### Web UI (InfluxDB 3 Explorer)
+
+Core has no built-in UI. Enable the optional [InfluxDB 3 Explorer](https://docs.influxdata.com/influxdb3/explorer/) web app with `explorer.enabled: true`. It is deployed as its own single-replica StatefulSet (image `influxdata/influxdb3-ui`) with its own Service and optional Ingress, and is pre-wired to the in-cluster Core server.
+
+Provide the API token Explorer uses to reach Core via `explorer.connection.token` (inline) or `explorer.connection.existingSecret` (a secret holding the raw `apiv3_...` token):
+
+```yaml
+explorer:
+  enabled: true
+  mode: admin                 # or "query" for read-only
+  connection:
+    enabled: true
+    database: mydb
+    existingSecret: influxdb-explorer-token   # key: token
+  ingress:
+    enabled: true
+    className: nginx
+    host: influxdb-explorer.example.com
+```
+
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | caching | string | `nil` |  |
+| explorer.affinity | object | `{}` |  |
+| explorer.connection.database | string | `""` | Default database to open (optional) |
+| explorer.connection.enabled | bool | `true` |  |
+| explorer.connection.existingSecret | string | `""` | Existing secret holding the raw API token (takes precedence over token) |
+| explorer.connection.existingSecretKey | string | `"token"` |  |
+| explorer.connection.server | string | `""` | Core server URL. Defaults to the in-cluster Core service when empty. |
+| explorer.connection.serverName | string | `"InfluxDB 3 Core"` | Display name for the server in Explorer |
+| explorer.connection.token | string | `""` |  |
+| explorer.enabled | bool | `false` |  |
+| explorer.image.pullPolicy | string | `"IfNotPresent"` |  |
+| explorer.image.registry | string | `"docker.io"` |  |
+| explorer.image.repository | string | `"influxdata/influxdb3-ui"` |  |
+| explorer.image.tag | string | `"1.8.0"` | Explorer image tag. Pin a version; see https://hub.docker.com/r/influxdata/influxdb3-ui/tags |
+| explorer.ingress.annotations | object | `{}` |  |
+| explorer.ingress.className | string | `""` |  |
+| explorer.ingress.enabled | bool | `false` |  |
+| explorer.ingress.host | string | `"influxdb-explorer.example.com"` |  |
+| explorer.ingress.tls | list | `[]` |  |
+| explorer.mode | string | `"admin"` | UI mode: "admin" (full management) or "query" (read-only) |
+| explorer.nodeSelector | object | `{}` |  |
+| explorer.persistence.accessMode | string | `"ReadWriteOnce"` |  |
+| explorer.persistence.enabled | bool | `true` |  |
+| explorer.persistence.size | string | `"1Gi"` |  |
+| explorer.persistence.storageClass | string | `""` |  |
+| explorer.persistence.volumeName | string | `""` | Bind the PVC to a specific PersistentVolume (e.g. a pre-created static PV) |
+| explorer.podAnnotations | object | `{}` |  |
+| explorer.podLabels | object | `{}` |  |
+| explorer.podSecurityContext | object | `{}` |  |
+| explorer.priorityClassName | string | `""` |  |
+| explorer.resources | object | `{}` |  |
+| explorer.securityContext | object | `{}` |  |
+| explorer.service.annotations | object | `{}` |  |
+| explorer.service.port | int | `8080` |  |
+| explorer.service.type | string | `"ClusterIP"` |  |
+| explorer.sessionSecret.existingSecret | string | `""` |  |
+| explorer.sessionSecret.existingSecretKey | string | `"session-secret"` |  |
+| explorer.sessionSecret.value | string | `""` |  |
+| explorer.tolerations | list | `[]` |  |
 | extraEnv | list | `[]` |  |
 | extraVolumeMounts | list | `[]` |  |
 | extraVolumes | list | `[]` |  |

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -121,6 +121,7 @@ kubectl delete statefulset <release-name>-influxdb3-core --cascade=orphan
 | objectStorage.file.persistence.enabled | bool | `true` | Create a PVC for the data directory. When disabled, an emptyDir is used and all data is lost when the pod restarts. |
 | objectStorage.file.persistence.size | string | `"50Gi"` |  |
 | objectStorage.file.persistence.storageClass | string | `""` |  |
+| objectStorage.file.persistence.volumeName | string | `""` | Bind the data PVC to a specific PersistentVolume (e.g. a pre-created static PV) |
 | objectStorage.google.existingSecret | string | `""` |  |
 | objectStorage.google.serviceAccountJson | string | `""` |  |
 | objectStorage.s3.accessKeyId | string | `""` |  |

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -1,6 +1,6 @@
 # influxdb3-core
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+![Version: 0.1.1](https://img.shields.io/badge/Version-0.1.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
 
 A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 

--- a/charts/influxdb3-core/README.md.gotmpl
+++ b/charts/influxdb3-core/README.md.gotmpl
@@ -57,6 +57,26 @@ Note: enabling the processing engine after the initial install adds a volumeClai
 kubectl delete statefulset <release-name>-influxdb3-core --cascade=orphan
 ```
 
+### Web UI (InfluxDB 3 Explorer)
+
+Core has no built-in UI. Enable the optional [InfluxDB 3 Explorer](https://docs.influxdata.com/influxdb3/explorer/) web app with `explorer.enabled: true`. It is deployed as its own single-replica StatefulSet (image `influxdata/influxdb3-ui`) with its own Service and optional Ingress, and is pre-wired to the in-cluster Core server.
+
+Provide the API token Explorer uses to reach Core via `explorer.connection.token` (inline) or `explorer.connection.existingSecret` (a secret holding the raw `apiv3_...` token):
+
+```yaml
+explorer:
+  enabled: true
+  mode: admin                 # or "query" for read-only
+  connection:
+    enabled: true
+    database: mydb
+    existingSecret: influxdb-explorer-token   # key: token
+  ingress:
+    enabled: true
+    className: nginx
+    host: influxdb-explorer.example.com
+```
+
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}

--- a/charts/influxdb3-core/templates/NOTES.txt
+++ b/charts/influxdb3-core/templates/NOTES.txt
@@ -62,4 +62,24 @@ Getting started:
 
      influxdb3 query mydb "SELECT * FROM measurement"
 
+{{- if .Values.explorer.enabled }}
+
+InfluxDB 3 Explorer (web UI) is enabled in "{{ .Values.explorer.mode }}" mode.
+{{- if .Values.explorer.ingress.enabled }}
+  UI: http{{ if .Values.explorer.ingress.tls }}s{{ end }}://{{ .Values.explorer.ingress.host }}
+{{- else }}
+  UI: kubectl port-forward svc/{{ include "influxdb3-core.explorer.fullname" . }} {{ .Values.explorer.service.port }}:{{ .Values.explorer.service.port }} -n {{ .Release.Namespace }}
+{{- end }}
+{{- if .Values.explorer.connection.enabled }}
+  Pre-configured to connect to {{ include "influxdb3-core.explorer.serverUrl" . }}
+  {{- if not (or .Values.explorer.connection.existingSecret .Values.explorer.connection.token) }}
+
+  ⚠️  explorer.connection.enabled is true but no API token is set.
+      Set explorer.connection.token or explorer.connection.existingSecret,
+      otherwise Explorer cannot authenticate to the Core server.
+  {{- end }}
+{{- end }}
+{{- end }}
+
 Documentation: https://docs.influxdata.com/influxdb3/core/
+Explorer docs:  https://docs.influxdata.com/influxdb3/explorer/

--- a/charts/influxdb3-core/templates/_helpers.tpl
+++ b/charts/influxdb3-core/templates/_helpers.tpl
@@ -401,3 +401,87 @@ Admin token volumes
         path: admin-token.json
 {{- end }}
 {{- end }}
+
+{{/*
+=============================================================================
+InfluxDB 3 Explorer (web UI) helpers
+=============================================================================
+*/}}
+
+{{/*
+Explorer fully qualified name
+*/}}
+{{- define "influxdb3-core.explorer.fullname" -}}
+{{- printf "%s-explorer" (include "influxdb3-core.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Explorer selector labels
+*/}}
+{{- define "influxdb3-core.explorer.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "influxdb3-core.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: explorer
+{{- end }}
+
+{{/*
+Explorer common labels
+*/}}
+{{- define "influxdb3-core.explorer.labels" -}}
+helm.sh/chart: {{ include "influxdb3-core.chart" . }}
+{{ include "influxdb3-core.explorer.selectorLabels" . }}
+{{- if .Values.explorer.image.tag }}
+app.kubernetes.io/version: {{ .Values.explorer.image.tag | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Explorer image reference
+*/}}
+{{- define "influxdb3-core.explorer.image" -}}
+{{- $registry := .Values.explorer.image.registry }}
+{{- $repository := .Values.explorer.image.repository }}
+{{- $tag := .Values.explorer.image.tag | default "latest" }}
+{{- printf "%s/%s:%s" $registry $repository $tag }}
+{{- end }}
+
+{{/*
+Explorer default server URL (in-cluster Core service) when not overridden
+*/}}
+{{- define "influxdb3-core.explorer.serverUrl" -}}
+{{- $conn := .Values.explorer.connection | default dict -}}
+{{- $server := get $conn "server" | default "" -}}
+{{- if $server -}}
+{{- $server -}}
+{{- else -}}
+{{- $scheme := ternary "https" "http" .Values.security.tls.enabled -}}
+{{- printf "%s://%s:%v" $scheme (include "influxdb3-core.fullname" .) .Values.service.port -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Explorer config secret name (holds the connection API token)
+*/}}
+{{- define "influxdb3-core.explorer.tokenSecretName" -}}
+{{- $conn := .Values.explorer.connection | default dict -}}
+{{- $existing := get $conn "existingSecret" | default "" -}}
+{{- if $existing -}}
+{{- $existing -}}
+{{- else -}}
+{{- printf "%s-connection" (include "influxdb3-core.explorer.fullname" .) -}}
+{{- end -}}
+{{- end }}
+
+{{/*
+Explorer session secret name
+*/}}
+{{- define "influxdb3-core.explorer.sessionSecretName" -}}
+{{- $session := .Values.explorer.sessionSecret | default dict -}}
+{{- $existing := get $session "existingSecret" | default "" -}}
+{{- if $existing -}}
+{{- $existing -}}
+{{- else -}}
+{{- printf "%s-session" (include "influxdb3-core.explorer.fullname" .) -}}
+{{- end -}}
+{{- end }}

--- a/charts/influxdb3-core/templates/explorer-ingress.yaml
+++ b/charts/influxdb3-core/templates/explorer-ingress.yaml
@@ -1,0 +1,38 @@
+{{- if and .Values.explorer.enabled .Values.explorer.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "influxdb3-core.explorer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.explorer.labels" . | nindent 4 }}
+  {{- with .Values.explorer.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.explorer.ingress.className }}
+  ingressClassName: {{ .Values.explorer.ingress.className }}
+  {{- end }}
+  {{- if .Values.explorer.ingress.tls }}
+  tls:
+    {{- range .Values.explorer.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    - host: {{ .Values.explorer.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "influxdb3-core.explorer.fullname" . }}
+                port:
+                  number: {{ .Values.explorer.service.port }}
+{{- end }}

--- a/charts/influxdb3-core/templates/explorer-secret.yaml
+++ b/charts/influxdb3-core/templates/explorer-secret.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.explorer.enabled }}
+{{- $conn := .Values.explorer.connection | default dict }}
+{{- $session := .Values.explorer.sessionSecret | default dict }}
+{{- if and $conn.enabled (not $conn.existingSecret) $conn.token }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "influxdb3-core.explorer.tokenSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.explorer.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ $conn.existingSecretKey | default "token" }}: {{ $conn.token | b64enc | quote }}
+{{- end }}
+{{- if and (not $session.existingSecret) $session.value }}
+{{- if and $conn.enabled (not $conn.existingSecret) $conn.token }}
+---
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "influxdb3-core.explorer.sessionSecretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.explorer.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ $session.existingSecretKey | default "session-secret" }}: {{ $session.value | b64enc | quote }}
+{{- end }}
+{{- end }}

--- a/charts/influxdb3-core/templates/explorer-service.yaml
+++ b/charts/influxdb3-core/templates/explorer-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.explorer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "influxdb3-core.explorer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.explorer.labels" . | nindent 4 }}
+  {{- with .Values.explorer.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.explorer.service.type }}
+  ports:
+    - port: {{ .Values.explorer.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "influxdb3-core.explorer.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/influxdb3-core/templates/explorer-statefulset.yaml
+++ b/charts/influxdb3-core/templates/explorer-statefulset.yaml
@@ -1,0 +1,172 @@
+{{- if .Values.explorer.enabled }}
+{{- $conn := .Values.explorer.connection | default dict }}
+{{- $session := .Values.explorer.sessionSecret | default dict }}
+{{- $persistence := .Values.explorer.persistence | default dict }}
+{{- $hasSessionSecret := or $session.existingSecret $session.value }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "influxdb3-core.explorer.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "influxdb3-core.explorer.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "influxdb3-core.explorer.fullname" . }}
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "influxdb3-core.explorer.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        {{- if $conn.enabled }}
+        checksum/connection: {{ printf "%s|%s|%s|%s" (include "influxdb3-core.explorer.serverUrl" .) ($conn.database | default "") ($conn.serverName | default "") (include "influxdb3-core.explorer.tokenSecretName" .) | sha256sum }}
+        {{- end }}
+        {{- with .Values.explorer.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "influxdb3-core.explorer.selectorLabels" . | nindent 8 }}
+        {{- with .Values.explorer.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "influxdb3-core.serviceAccountName" . }}
+      {{- if .Values.explorer.priorityClassName }}
+      priorityClassName: {{ .Values.explorer.priorityClassName }}
+      {{- end }}
+      {{- with .Values.explorer.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if $conn.enabled }}
+      initContainers:
+        - name: render-config
+          image: {{ include "influxdb3-core.explorer.image" . }}
+          imagePullPolicy: {{ .Values.explorer.image.pullPolicy }}
+          {{- with .Values.explorer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              umask 077
+              cat > /app-root/config/config.json <<JSON
+              {
+                "DEFAULT_INFLUX_SERVER": "${DEFAULT_INFLUX_SERVER}",
+                "DEFAULT_INFLUX_DATABASE": "${DEFAULT_INFLUX_DATABASE}",
+                "DEFAULT_API_TOKEN": "${DEFAULT_API_TOKEN}",
+                "DEFAULT_SERVER_NAME": "${DEFAULT_SERVER_NAME}"
+              }
+              JSON
+          env:
+            - name: DEFAULT_INFLUX_SERVER
+              value: {{ include "influxdb3-core.explorer.serverUrl" . | quote }}
+            - name: DEFAULT_INFLUX_DATABASE
+              value: {{ $conn.database | default "" | quote }}
+            - name: DEFAULT_SERVER_NAME
+              value: {{ $conn.serverName | default "InfluxDB 3 Core" | quote }}
+            - name: DEFAULT_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "influxdb3-core.explorer.tokenSecretName" . }}
+                  key: {{ $conn.existingSecretKey | default "token" }}
+          volumeMounts:
+            - name: config
+              mountPath: /app-root/config
+      {{- end }}
+      containers:
+        - name: explorer
+          {{- with .Values.explorer.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "influxdb3-core.explorer.image" . }}
+          imagePullPolicy: {{ .Values.explorer.image.pullPolicy }}
+          args:
+            - --mode={{ .Values.explorer.mode }}
+          {{- if $hasSessionSecret }}
+          env:
+            - name: SESSION_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "influxdb3-core.explorer.sessionSecretName" . }}
+                  key: {{ $session.existingSecretKey | default "session-secret" }}
+          {{- end }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          {{- if .Values.probes.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+          {{- end }}
+          resources:
+            {{- toYaml .Values.explorer.resources | nindent 12 }}
+          volumeMounts:
+            - name: db
+              mountPath: /db
+            {{- if $conn.enabled }}
+            - name: config
+              mountPath: /app-root/config
+            {{- end }}
+      {{- with .Values.explorer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.explorer.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.explorer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if $conn.enabled }}
+        - name: config
+          emptyDir: {}
+        {{- end }}
+        {{- if not $persistence.enabled }}
+        - name: db
+          emptyDir: {}
+        {{- end }}
+  {{- if $persistence.enabled }}
+  volumeClaimTemplates:
+    - metadata:
+        name: db
+      spec:
+        accessModes:
+          - {{ $persistence.accessMode }}
+      {{- if $persistence.storageClass }}
+        storageClassName: {{ $persistence.storageClass | quote }}
+      {{- end }}
+      {{- if $persistence.volumeName }}
+        volumeName: {{ $persistence.volumeName | quote }}
+      {{- end }}
+        resources:
+          requests:
+            storage: {{ $persistence.size }}
+  {{- end }}
+{{- end }}

--- a/charts/influxdb3-core/templates/statefulset.yaml
+++ b/charts/influxdb3-core/templates/statefulset.yaml
@@ -164,6 +164,9 @@ spec:
       {{- if .Values.objectStorage.file.persistence.storageClass }}
         storageClassName: {{ .Values.objectStorage.file.persistence.storageClass | quote }}
       {{- end }}
+      {{- if .Values.objectStorage.file.persistence.volumeName }}
+        volumeName: {{ .Values.objectStorage.file.persistence.volumeName | quote }}
+      {{- end }}
         resources:
           requests:
             storage: {{ .Values.objectStorage.file.persistence.size }}

--- a/charts/influxdb3-core/values.yaml
+++ b/charts/influxdb3-core/values.yaml
@@ -65,6 +65,8 @@ objectStorage:
       storageClass: ""
       size: 50Gi
       accessMode: ReadWriteOnce
+      # -- Bind the data PVC to a specific PersistentVolume (e.g. a pre-created static PV)
+      volumeName: ""
 
   # S3 and S3-compatible storage (MinIO, etc.)
   # To use S3, set objectStorage.type: s3

--- a/charts/influxdb3-core/values.yaml
+++ b/charts/influxdb3-core/values.yaml
@@ -377,6 +377,94 @@ ingress:
   #       - influxdb.example.com
 
 # ============================================================================
+# InfluxDB 3 Explorer (web UI, optional)
+# ============================================================================
+# InfluxDB 3 Core ships no built-in UI. Explorer is a separate web app
+# (influxdata/influxdb3-ui) for querying, visualizing and managing data.
+# When enabled it is deployed as its own single-replica StatefulSet with its
+# own Service and (optional) Ingress, pre-wired to the in-cluster Core server.
+
+explorer:
+  enabled: false
+
+  image:
+    registry: docker.io
+    repository: influxdata/influxdb3-ui
+    # -- Explorer image tag. Pin a version; see https://hub.docker.com/r/influxdata/influxdb3-ui/tags
+    tag: "1.8.0"
+    pullPolicy: IfNotPresent
+
+  # -- UI mode: "admin" (full management) or "query" (read-only)
+  mode: admin
+
+  # Pre-configure the default server connection (renders /app-root/config/config.json).
+  # When connection.enabled is false, configure the connection in the UI at runtime.
+  connection:
+    enabled: true
+    # -- Display name for the server in Explorer
+    serverName: "InfluxDB 3 Core"
+    # -- Core server URL. Defaults to the in-cluster Core service when empty.
+    server: ""
+    # -- Default database to open (optional)
+    database: ""
+    # API token Explorer uses to reach Core. Provide inline OR via an existing secret.
+    # The token must be the raw token string (e.g. apiv3_...), not the admin-token.json wrapper.
+    token: ""
+    # -- Existing secret holding the raw API token (takes precedence over token)
+    existingSecret: ""
+    existingSecretKey: "token"
+
+  # SESSION_SECRET_KEY - set to persist UI sessions across restarts.
+  # When left empty the container generates a random key on each start.
+  sessionSecret:
+    value: ""
+    existingSecret: ""
+    existingSecretKey: "session-secret"
+
+  # Persistent storage for Explorer's SQLite state (/db: saved queries, sessions)
+  persistence:
+    enabled: true
+    storageClass: ""
+    size: 1Gi
+    accessMode: ReadWriteOnce
+    # -- Bind the PVC to a specific PersistentVolume (e.g. a pre-created static PV)
+    volumeName: ""
+
+  resources: {}
+
+  # Security context
+  podSecurityContext: {}
+  securityContext: {}
+
+  # Service configuration
+  service:
+    type: ClusterIP
+    port: 8080
+    annotations: {}
+
+  # Ingress for the Explorer UI
+  ingress:
+    enabled: false
+    host: "influxdb-explorer.example.com"
+    className: ""
+    annotations: {}
+    tls: []
+    # tls:
+    #   - secretName: influxdb-explorer-tls
+    #     hosts:
+    #       - influxdb-explorer.example.com
+
+  # Scheduling
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+  priorityClassName: ""
+
+  # Additional pod annotations and labels
+  podAnnotations: {}
+  podLabels: {}
+
+# ============================================================================
 # Network Policies (optional, disabled by default)
 # ============================================================================
 # To enable network policies, set networkPolicy.enabled: true


### PR DESCRIPTION
## Summary

Adds the optional [InfluxDB 3 Explorer](https://docs.influxdata.com/influxdb3/explorer/) web UI to the `influxdb3-core` chart (bump to 0.2.0). InfluxDB 3 Core ships no built-in UI; Explorer (`influxdata/influxdb3-ui`) is the standalone web app for querying, visualizing and managing data.

Disabled by default (`explorer.enabled: false`) — existing installs are unaffected.

## Details

- Single-replica StatefulSet with its own Service and optional Ingress (Explorer has a UI, so it gets its own ingress on port 8080)
- Connection pre-wiring: an initContainer renders `/app-root/config/config.json` (the only supported pre-config method — connection settings are not env vars) from the API token, sourced inline (`explorer.connection.token`) or from an existing secret (`explorer.connection.existingSecret`, raw `apiv3_` token)
- `mode: admin` (full) or `query` (read-only)
- Optional `SESSION_SECRET_KEY` (inline or existing secret) to persist sessions
- `/db` SQLite state on a PVC (`explorer.persistence`, supports `volumeName`), or emptyDir when disabled
- HTTP liveness/readiness probes; server URL defaults to the in-cluster Core service

## Testing

- `helm lint`: pass
- `helm template` scenarios: inline token + ingress + session secret, existingSecret + no persistence, and disabled (renders zero Explorer resources)
- `kubeconform -strict`: all valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)