### PR TITLE
influxdb3-core 0.2.1: fix processing-engine venv crash when disabled

### DIFF
--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-core
 description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -1,6 +1,6 @@
 # influxdb3-core
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
 
 A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 

--- a/charts/influxdb3-core/templates/statefulset.yaml
+++ b/charts/influxdb3-core/templates/statefulset.yaml
@@ -79,6 +79,12 @@ spec:
             - /bin/sh
             - -c
             - |
+              {{- if not .Values.processingEngine.enabled }}
+              # The Docker image sets INFLUXDB3_PLUGIN_DIR=/plugins, which makes
+              # Core initialize the Python processing engine on startup. Unset it
+              # when the processing engine is disabled so no virtualenv is needed.
+              unset INFLUXDB3_PLUGIN_DIR
+              {{- end }}
               exec influxdb3 \
                 {{- with .Values.numIOThreads }}
                 --num-io-threads={{ . }} \


### PR DESCRIPTION
## Problem

Deploying the chart with the processing engine disabled (the default) crashes the Core container on startup:

```
Serve command failed: Python environment initialization failed: Virtual environment error:
Failed to initialize virtualenv: Activation script not found at "/plugins/.venv/bin/activate"
```

## Cause

The official `influxdb:*-core` Docker image bakes `INFLUXDB3_PLUGIN_DIR=/plugins`. Core treats a configured plugin dir as "processing engine enabled" and initializes a Python virtualenv at startup, which fails when no working venv exists (and the var cannot be cleared by setting it empty — per the [docs](https://docs.influxdata.com/influxdb3/core/reference/config-options/) it must be unset).

The chart only avoided setting the var; it never cleared the image's default, so a default install always tripped over the engine.

## Fix

When `processingEngine.enabled` is false, `unset INFLUXDB3_PLUGIN_DIR` in the serve command before `exec`, so the server starts without the Python engine. No change when the engine is enabled. Bumps chart to 0.2.1.

## Testing

- `helm lint`: pass
- `helm template`: `unset INFLUXDB3_PLUGIN_DIR` present when engine disabled, absent when enabled
- `kubeconform -strict`: valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)