### PR TITLE
influxdb3-core 0.2.2: stop Core Service from selecting Explorer pods

### DIFF
--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-core
 description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -1,6 +1,6 @@
 # influxdb3-core
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+![Version: 0.2.2](https://img.shields.io/badge/Version-0.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
 
 A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 

--- a/charts/influxdb3-core/templates/_helpers.tpl
+++ b/charts/influxdb3-core/templates/_helpers.tpl
@@ -49,6 +49,19 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Server (core) selector labels - selectorLabels plus a component label so the
+Core Service does not also match the Explorer pods (same name/instance).
+Used for the Service/ServiceMonitor/NetworkPolicy selectors and the pod labels.
+NOTE: deliberately NOT used for the StatefulSet .spec.selector, which is
+immutable - existing installs upgrade with a rolling restart (the pod just
+gains the component label) instead of requiring a recreate.
+*/}}
+{{- define "influxdb3-core.server.selectorLabels" -}}
+{{ include "influxdb3-core.selectorLabels" . }}
+app.kubernetes.io/component: database
+{{- end }}
+
+{{/*
 Service account name
 */}}
 {{- define "influxdb3-core.serviceAccountName" -}}

--- a/charts/influxdb3-core/templates/networkpolicy.yaml
+++ b/charts/influxdb3-core/templates/networkpolicy.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "influxdb3-core.selectorLabels" . | nindent 6 }}
+      {{- include "influxdb3-core.server.selectorLabels" . | nindent 6 }}
   policyTypes:
     {{- toYaml .Values.networkPolicy.policyTypes | nindent 4 }}
   ingress:

--- a/charts/influxdb3-core/templates/service.yaml
+++ b/charts/influxdb3-core/templates/service.yaml
@@ -17,4 +17,4 @@ spec:
       protocol: TCP
       name: http
   selector:
-    {{- include "influxdb3-core.selectorLabels" . | nindent 4 }}
+    {{- include "influxdb3-core.server.selectorLabels" . | nindent 4 }}

--- a/charts/influxdb3-core/templates/servicemonitor.yaml
+++ b/charts/influxdb3-core/templates/servicemonitor.yaml
@@ -18,7 +18,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "influxdb3-core.selectorLabels" . | nindent 6 }}
+      {{- include "influxdb3-core.server.selectorLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/influxdb3-core/templates/statefulset.yaml
+++ b/charts/influxdb3-core/templates/statefulset.yaml
@@ -36,7 +36,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "influxdb3-core.selectorLabels" . | nindent 8 }}
+        {{- include "influxdb3-core.server.selectorLabels" . | nindent 8 }}
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}


### PR DESCRIPTION
## Problem

With Explorer enabled, the Core Service ends up with two endpoints (`core:8181` and `explorer:8080`) and round-robins requests to Explorer, which returns its SPA HTML. This breaks Explorer's own connection bootstrap — `tryPing` on `/ping` receives HTML, so the default server config is never created and the UI shows:

```
Active configuration not found: Please configure and activate a server connection first
```

## Cause

The Core Service / ServiceMonitor / NetworkPolicy selected pods by `app.kubernetes.io/name` + `app.kubernetes.io/instance` only. The Explorer pod shares those labels (it adds `component=explorer`), so it also matched the Core selectors.

## Fix

Add `app.kubernetes.io/component: database` to the Core pods and use it in the Core Service / ServiceMonitor / NetworkPolicy selectors via a new `influxdb3-core.server.selectorLabels` helper. The StatefulSet `.spec.selector` is intentionally left unchanged (it is immutable), so existing installs upgrade with a rolling restart — the pod simply gains the component label — rather than requiring a recreate. Bumps chart to 0.2.2.

Verified against a live deploy: Core `/ping` returns `401` JSON (a real endpoint; the config.json token satisfies it) and `/health` returns `200` — the HTML was solely the Explorer pod being hit through the shared Service.

## Testing

- `helm lint`: pass
- `helm template`: Core Service selector now includes `component: database`; StatefulSet `.spec.selector` unchanged (name+instance); pod + service carry the component label
- `kubeconform -strict`: valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)