### PR TITLE
influxdb3-core 0.4.0: support extra manifests

### DIFF
--- a/charts/influxdb3-core/Chart.yaml
+++ b/charts/influxdb3-core/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: influxdb3-core
 description: A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 type: application
-version: 0.3.0
+version: 0.4.0
 appVersion: "3.9.3"
 keywords:
   - influxdb

--- a/charts/influxdb3-core/README.md
+++ b/charts/influxdb3-core/README.md
@@ -1,6 +1,6 @@
 # influxdb3-core
 
-![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.3](https://img.shields.io/badge/AppVersion-3.9.3-informational?style=flat-square)
 
 A Helm chart for deploying InfluxDB 3 Core on Kubernetes
 
@@ -108,170 +108,13 @@ explorer:
     operator.1password.io/item-name: "influxdb-explorer-token" # Explorer reads the raw-token key
 ```
 
-## Values
+### Extra manifests
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| affinity | object | `{}` |  |
-| caching | string | `nil` |  |
-| explorer.affinity | object | `{}` |  |
-| explorer.annotations | object | `{}` | Annotations for the Explorer StatefulSet object itself (controller metadata, not the pods), e.g. 1Password operator item-path/item-name. |
-| explorer.connection.database | string | `""` | Default database to open (optional) |
-| explorer.connection.enabled | bool | `true` |  |
-| explorer.connection.existingSecret | string | `""` | Existing secret holding the raw API token (takes precedence over token) |
-| explorer.connection.existingSecretKey | string | `"token"` |  |
-| explorer.connection.server | string | `""` | Core server URL. Defaults to the in-cluster Core service when empty. |
-| explorer.connection.serverName | string | `"InfluxDB 3 Core"` | Display name for the server in Explorer |
-| explorer.connection.token | string | `""` |  |
-| explorer.enabled | bool | `false` |  |
-| explorer.image.pullPolicy | string | `"IfNotPresent"` |  |
-| explorer.image.registry | string | `"docker.io"` |  |
-| explorer.image.repository | string | `"influxdata/influxdb3-ui"` |  |
-| explorer.image.tag | string | `"1.8.0"` | Explorer image tag. Pin a version; see https://hub.docker.com/r/influxdata/influxdb3-ui/tags |
-| explorer.ingress.annotations | object | `{}` |  |
-| explorer.ingress.className | string | `""` |  |
-| explorer.ingress.enabled | bool | `false` |  |
-| explorer.ingress.host | string | `"influxdb-explorer.example.com"` |  |
-| explorer.ingress.tls | list | `[]` |  |
-| explorer.mode | string | `"admin"` | UI mode: "admin" (full management) or "query" (read-only) |
-| explorer.nodeSelector | object | `{}` |  |
-| explorer.persistence.accessMode | string | `"ReadWriteOnce"` |  |
-| explorer.persistence.enabled | bool | `true` |  |
-| explorer.persistence.size | string | `"1Gi"` |  |
-| explorer.persistence.storageClass | string | `""` |  |
-| explorer.persistence.volumeName | string | `""` | Bind the PVC to a specific PersistentVolume (e.g. a pre-created static PV) |
-| explorer.podAnnotations | object | `{}` |  |
-| explorer.podLabels | object | `{}` |  |
-| explorer.podSecurityContext | object | `{}` |  |
-| explorer.priorityClassName | string | `""` |  |
-| explorer.resources | object | `{}` |  |
-| explorer.securityContext | object | `{}` |  |
-| explorer.service.annotations | object | `{}` |  |
-| explorer.service.port | int | `8080` |  |
-| explorer.service.type | string | `"ClusterIP"` |  |
-| explorer.sessionSecret.existingSecret | string | `""` |  |
-| explorer.sessionSecret.existingSecretKey | string | `"session-secret"` |  |
-| explorer.sessionSecret.value | string | `""` |  |
-| explorer.tolerations | list | `[]` |  |
-| extraEnv | list | `[]` |  |
-| extraVolumeMounts | list | `[]` |  |
-| extraVolumes | list | `[]` |  |
-| fullnameOverride | string | `""` |  |
-| global.annotations | object | `{}` | Annotations merged into both StatefulSet objects (controller metadata) |
-| global.podAnnotations | object | `{}` | Annotations merged into both pod templates |
-| global.podLabels | object | `{}` | Labels merged into both pod templates |
-| http | string | `nil` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.registry | string | `"docker.io"` |  |
-| image.repository | string | `"influxdb"` |  |
-| image.tag | string | `""` | Optional explicit tag override. If empty, defaults to "<appVersion>-core". |
-| imagePullSecrets | list | `[]` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.className | string | `""` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.host | string | `"influxdb.example.com"` |  |
-| ingress.tls | list | `[]` |  |
-| nameOverride | string | `""` |  |
-| networkPolicy.egress.dns.namespace | string | `"kube-system"` |  |
-| networkPolicy.egress.dns.namespaceLabel | string | `"kubernetes.io/metadata.name"` |  |
-| networkPolicy.egress.dns.podLabelKey | string | `"k8s-app"` |  |
-| networkPolicy.egress.dns.podLabelValue | string | `"kube-dns"` |  |
-| networkPolicy.egress.objectStorageCidrs | list | `[]` |  |
-| networkPolicy.egress.pluginEndpointCidrs | list | `[]` |  |
-| networkPolicy.egress.toDns | bool | `true` |  |
-| networkPolicy.egress.toObjectStorage | bool | `true` |  |
-| networkPolicy.egress.toPluginEndpoints | bool | `true` |  |
-| networkPolicy.enabled | bool | `false` |  |
-| networkPolicy.ingress.fromIngressController | bool | `true` |  |
-| networkPolicy.ingress.fromPrometheus | bool | `false` |  |
-| networkPolicy.ingress.ingressController.namespace | string | `"ingress-nginx"` |  |
-| networkPolicy.ingress.ingressController.namespaceLabel | string | `"kubernetes.io/metadata.name"` |  |
-| networkPolicy.ingress.ingressController.podLabelKey | string | `"app.kubernetes.io/name"` |  |
-| networkPolicy.ingress.ingressController.podLabelValue | string | `"ingress-nginx"` |  |
-| networkPolicy.ingress.prometheus.namespace | string | `"monitoring"` |  |
-| networkPolicy.ingress.prometheus.namespaceLabel | string | `"kubernetes.io/metadata.name"` |  |
-| networkPolicy.ingress.prometheus.podLabelKey | string | `"app.kubernetes.io/name"` |  |
-| networkPolicy.ingress.prometheus.podLabelValue | string | `"prometheus"` |  |
-| networkPolicy.policyTypes[0] | string | `"Ingress"` |  |
-| networkPolicy.policyTypes[1] | string | `"Egress"` |  |
-| node.id | string | `""` | Node identifier, must be unique among hosts sharing the same object store. If empty, the pod hostname is used (stable for a StatefulSet). |
-| nodeSelector | object | `{}` |  |
-| objectStorage.azure.accessKey | string | `""` |  |
-| objectStorage.azure.allowHttp | bool | `false` |  |
-| objectStorage.azure.endpoint | string | `""` |  |
-| objectStorage.azure.existingSecret | string | `""` |  |
-| objectStorage.azure.storageAccount | string | `""` |  |
-| objectStorage.bucket | string | `"influxdb3-core-data"` | Bucket/container name for storing data (s3, azure, google) |
-| objectStorage.file.dataDir | string | `"/var/lib/influxdb3"` |  |
-| objectStorage.file.persistence.accessMode | string | `"ReadWriteOnce"` |  |
-| objectStorage.file.persistence.enabled | bool | `true` | Create a PVC for the data directory. When disabled, an emptyDir is used and all data is lost when the pod restarts. |
-| objectStorage.file.persistence.size | string | `"50Gi"` |  |
-| objectStorage.file.persistence.storageClass | string | `""` |  |
-| objectStorage.file.persistence.volumeName | string | `""` | Bind the data PVC to a specific PersistentVolume (e.g. a pre-created static PV) |
-| objectStorage.google.existingSecret | string | `""` |  |
-| objectStorage.google.serviceAccountJson | string | `""` |  |
-| objectStorage.s3.accessKeyId | string | `""` |  |
-| objectStorage.s3.credentialsFile | string | `""` |  |
-| objectStorage.s3.endpoint | string | `""` |  |
-| objectStorage.s3.existingSecret | string | `""` |  |
-| objectStorage.s3.region | string | `"us-east-1"` |  |
-| objectStorage.s3.secretAccessKey | string | `""` |  |
-| objectStorage.s3.sessionToken | string | `""` |  |
-| objectStorage.type | string | `"file"` | Object store type: file, s3, azure, google, memory, memory-throttled |
-| podSecurityContext.fsGroup | int | `1500` |  |
-| podSecurityContext.runAsGroup | int | `1500` |  |
-| podSecurityContext.runAsNonRoot | bool | `true` |  |
-| podSecurityContext.runAsUser | int | `1500` |  |
-| priorityClassName | string | `""` |  |
-| probes.enabled | bool | `true` |  |
-| probes.liveness.failureThreshold | int | `3` |  |
-| probes.liveness.initialDelaySeconds | int | `0` |  |
-| probes.liveness.periodSeconds | int | `10` |  |
-| probes.liveness.timeoutSeconds | int | `5` |  |
-| probes.readiness.failureThreshold | int | `3` |  |
-| probes.readiness.initialDelaySeconds | int | `0` |  |
-| probes.readiness.periodSeconds | int | `5` |  |
-| probes.readiness.timeoutSeconds | int | `3` |  |
-| probes.startup.failureThreshold | int | `12` |  |
-| probes.startup.initialDelaySeconds | int | `10` |  |
-| probes.startup.periodSeconds | int | `5` |  |
-| probes.startup.timeoutSeconds | int | `5` |  |
-| processingEngine.enabled | bool | `false` |  |
-| processingEngine.initPlugins | list | `[]` |  |
-| processingEngine.persistence.accessMode | string | `"ReadWriteOnce"` |  |
-| processingEngine.persistence.enabled | bool | `true` |  |
-| processingEngine.persistence.size | string | `"5Gi"` |  |
-| processingEngine.persistence.storageClass | string | `""` |  |
-| processingEngine.pluginDir | string | `"/plugins"` | Local directory that contains Python plugins and their test files (--plugin-dir) |
-| resources | object | `{}` |  |
-| security.auth.adminToken.existingSecret | string | `""` |  |
-| security.auth.adminToken.file | string | `""` |  |
-| security.auth.disableAuthz[0] | string | `"health"` |  |
-| security.auth.disabled | bool | `false` |  |
-| security.tls.cert | string | `""` |  |
-| security.tls.certPath | string | `"/etc/influxdb/tls/tls.crt"` |  |
-| security.tls.enabled | bool | `false` |  |
-| security.tls.existingSecret | string | `""` |  |
-| security.tls.key | string | `""` |  |
-| security.tls.keyPath | string | `"/etc/influxdb/tls/tls.key"` |  |
-| security.tls.minVersion | string | `"tls-1.2"` |  |
-| securityContext | object | `{}` |  |
-| server.annotations | object | `{}` | Annotations for the Core StatefulSet object (controller metadata, not the pods). Use for controllers that watch the workload object, e.g. the 1Password operator's operator.1password.io/item-path and item-name annotations. |
-| server.podAnnotations | object | `{}` | Annotations for the Core pods |
-| server.podLabels | object | `{}` | Labels for the Core pods |
-| service.annotations | object | `{}` |  |
-| service.port | int | `8181` |  |
-| service.type | string | `"ClusterIP"` |  |
-| serviceAccount.annotations | object | `{}` |  |
-| serviceAccount.create | bool | `true` |  |
-| serviceAccount.name | string | `""` |  |
-| serviceMonitor.additionalLabels | object | `{}` |  |
-| serviceMonitor.enabled | bool | `false` |  |
-| serviceMonitor.interval | string | `"30s"` |  |
-| serviceMonitor.namespace | string | `""` |  |
-| serviceMonitor.scrapeTimeout | string | `"10s"` |  |
-| tolerations | list | `[]` |  |
-| updateStrategy.type | string | `"RollingUpdate"` |  |
+Deploy arbitrary additional manifests alongside the chart with `extraManifests`. Each entry may be a structured object or a raw YAML string; both are run through `tpl`, so templating against `.Release` and `.Values` works:
 
-----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)
+```yaml
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: "

--- a/charts/influxdb3-core/README.md.gotmpl
+++ b/charts/influxdb3-core/README.md.gotmpl
@@ -101,6 +101,27 @@ explorer:
     operator.1password.io/item-name: "influxdb-explorer-token" # Explorer reads the raw-token key
 ```
 
+### Extra manifests
+
+Deploy arbitrary additional manifests alongside the chart with `extraManifests`. Each entry may be a structured object or a raw YAML string; both are run through `tpl`, so templating against `.Release` and `.Values` works:
+
+```yaml
+extraManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: "{{ .Release.Name }}-extra"
+    data:
+      key: value
+  - |
+    apiVersion: v1
+    kind: Secret
+    metadata:
+      name: my-extra-secret
+    stringData:
+      token: "{{ .Values.someValue }}"
+```
+
 {{ template "chart.requirementsSection" . }}
 
 {{ template "chart.valuesSection" . }}

--- a/charts/influxdb3-core/templates/extra-manifests.yaml
+++ b/charts/influxdb3-core/templates/extra-manifests.yaml
@@ -1,0 +1,8 @@
+{{- range .Values.extraManifests }}
+---
+{{- if typeIs "string" . }}
+{{ tpl . $ }}
+{{- else }}
+{{ tpl (toYaml .) $ }}
+{{- end }}
+{{- end }}

--- a/charts/influxdb3-core/values.yaml
+++ b/charts/influxdb3-core/values.yaml
@@ -606,3 +606,21 @@ extraVolumes: []
 extraVolumeMounts: []
   # - name: custom-config
 #   mountPath: /etc/custom
+
+# Extra Kubernetes manifests to deploy alongside the chart. Each item may be a
+# structured object or a (templated) raw YAML string; both are passed through
+# `tpl`, so `{{ }}` expressions and `.Release` / `.Values` references work.
+extraManifests: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: "{{ .Release.Name }}-extra"
+  #   data:
+  #     key: value
+  # - |
+  #   apiVersion: v1
+  #   kind: Secret
+  #   metadata:
+  #     name: my-extra-secret
+  #   stringData:
+  #     token: "{{ .Values.someValue }}"


### PR DESCRIPTION
## Summary

Adds an `extraManifests` value for deploying arbitrary Kubernetes manifests alongside the chart. Each entry may be a **structured object** or a **raw YAML string**; both are passed through `tpl`, so templating against `.Release` and `.Values` works. Bumps chart to 0.4.0.

```yaml
extraManifests:
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: "{{ .Release.Name }}-extra"
    data:
      key: value
  - |
    apiVersion: v1
    kind: Secret
    metadata:
      name: my-extra-secret
    stringData:
      token: "{{ .Values.someValue }}"
```

## Testing

- `helm lint`: pass
- `helm template`: object and templated-string entries both render and tpl-process (`.Release.Name` resolved); empty default emits nothing
- `kubeconform -strict`: valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)